### PR TITLE
Add CI pipeline with GitHub Actions and zizmor scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24"
@@ -24,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24"
@@ -34,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24"
@@ -44,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Build Docker image
         run: docker build -t reel-life:test .
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with test, build, vet, Docker build, and zizmor security scanning jobs
- All actions pinned to full SHA hashes for supply chain security
- Zizmor scans workflow files themselves for security misconfigurations (unpinned actions, excessive permissions, credential leaks)

## Test plan
- [ ] CI jobs pass on this PR (test, build, vet, docker, zizmor)
- [ ] Verify zizmor reports no findings on the workflow file

Run: 20260328-1613-17f0

🤖 Generated with [Claude Code](https://claude.com/claude-code)