### PR TITLE
Harden NixOS systemd service and add network allowlisting

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -22,11 +22,24 @@
 #       family = "inet";
 #       content = ''
 #         chain output {
-#           type filter hook output priority 0; policy accept;
+#           type filter hook output priority 0; policy drop;
+#
+#           # Allow loopback traffic
+#           oifname "lo" accept;
+#
+#           # Allow established/related connections
+#           ct state { established, related } accept;
+#
+#           # Allow DNS queries from the service user
+#           meta skuid "reel-life" udp dport 53 accept;
+#           meta skuid "reel-life" tcp dport 53 accept;
+#
+#           # Allow access to required services
 #           meta skuid "reel-life" tcp dport { 80, 443 } ip daddr {
-#             127.0.0.1, # Sonarr
-#           } accept
-#           meta skuid "reel-life" tcp dport { 80, 443 } drop
+#             127.0.0.1,           # Sonarr
+#             api.anthropic.com,   # Anthropic (resolved at rule load time)
+#             chat.googleapis.com  # Google Chat (resolved at rule load time)
+#           } accept;
 #         }
 #       '';
 #     };


### PR DESCRIPTION
## Summary
- Extends the NixOS module's systemd service with comprehensive sandboxing: full kernel protection, capability dropping, syscall filtering (`@system-service` allowlist), namespace/address-family restrictions, and resource limits (256M/50% CPU/32 tasks)
- Adds `restrictNetwork` and `allowedHosts` options for IP-based network allowlisting via systemd's `IPAddressAllow`/`IPAddressDeny`
- Documents nftables-based alternative for DNS-aware filtering of external APIs (Anthropic, Google Chat) whose IPs change dynamically

## Test plan
- [x] `nix flake check` passes — module evaluates correctly
- [x] `go build ./...` and `go test ./...` still pass
- [ ] Deploy to a NixOS host and verify `systemd-analyze security reel-life` scores ~2.0
- [ ] Verify service starts and can reach Sonarr on localhost
- [ ] Test `restrictNetwork = true` blocks unexpected outbound connections
- [ ] Test adding external API IPs to `allowedHosts` restores Anthropic/Google access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Run: 20260328-1646-5460