### PR TITLE
Make HTTP listen port configurable, default to 9090

### DIFF
--- a/cmd/reel-life/main.go
+++ b/cmd/reel-life/main.go
@@ -140,7 +140,7 @@ func main() {
 	mux.Handle("POST /webhook", webhookHandler)
 
 	server := &http.Server{
-		Addr:    ":8080",
+		Addr:    cfg.ListenAddr(),
 		Handler: mux,
 	}
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -25,3 +25,6 @@ monitor:
 log:
   level: info    # debug, info, warn, error
   format: text   # text or json
+
+server:
+  port: 9090     # HTTP port for health checks and webhooks

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,11 @@ type Config struct {
 	Agent   AgentConfig   `yaml:"agent"`
 	Monitor MonitorConfig `yaml:"monitor"`
 	Log     LogConfig     `yaml:"log"`
+	Server  ServerConfig  `yaml:"server"`
+}
+
+type ServerConfig struct {
+	Port int `yaml:"port"`
 }
 
 type SonarrConfig struct {
@@ -128,6 +133,14 @@ func validate(cfg *Config) error {
 		return fmt.Errorf("chat.webhook_url or chat.service_account_file + chat.space is required")
 	}
 	return nil
+}
+
+func (c *Config) ListenAddr() string {
+	port := c.Server.Port
+	if port == 0 {
+		port = 9090
+	}
+	return fmt.Sprintf(":%d", port)
 }
 
 func (cfg *Config) LogLevel() slog.Level {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,6 +257,44 @@ chat:
 	}
 }
 
+func TestListenAddrDefault(t *testing.T) {
+	yaml := `
+sonarr:
+  base_url: http://sonarr:8989
+  api_key: test-key
+chat:
+  webhook_url: https://chat.example.com/webhook
+`
+	path := writeTemp(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if got := cfg.ListenAddr(); got != ":9090" {
+		t.Errorf("ListenAddr() = %q, want %q", got, ":9090")
+	}
+}
+
+func TestListenAddrCustom(t *testing.T) {
+	yaml := `
+sonarr:
+  base_url: http://sonarr:8989
+  api_key: test-key
+chat:
+  webhook_url: https://chat.example.com/webhook
+server:
+  port: 3000
+`
+	path := writeTemp(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if got := cfg.ListenAddr(); got != ":3000" {
+		t.Errorf("ListenAddr() = %q, want %q", got, ":3000")
+	}
+}
+
 func writeTemp(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -111,6 +111,12 @@ in
       description = "Log format (text, json)";
     };
 
+    listenPort = lib.mkOption {
+      type = lib.types.port;
+      default = 9090;
+      description = "HTTP port for health checks and webhooks";
+    };
+
     environmentFiles = lib.mkOption {
       type = lib.types.listOf lib.types.path;
       default = [ ];
@@ -170,6 +176,8 @@ in
       log:
         level: "${cfg.logLevel}"
         format: "${cfg.logFormat}"
+      server:
+        port: ${toString cfg.listenPort}
     '';
 
     systemd.services.reel-life = {


### PR DESCRIPTION
## Summary
- Add `server.port` config field with `ListenAddr()` helper (defaults to 9090 when unset)
- Replace hardcoded `:8080` in `cmd/reel-life/main.go` with `cfg.ListenAddr()`
- Expose `listenPort` option in the NixOS module and wire it into generated config
- Update `config.yaml.example` with the new server section
- Add tests for default and custom port behavior

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./...` — all tests pass, including new `TestListenAddrDefault` and `TestListenAddrCustom`
- [x] `klaus _pre-review` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Run: 20260401-2126-374c