### PR TITLE
Fix NixOS module YAML: nest telegram fields under chat key

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -164,7 +164,6 @@ in
         base_url: "${cfg.sonarrUrl}"
       chat:
         backend: "${cfg.chatBackend}"${lib.optionalString (cfg.chatBackend == "telegram") ''
-
         telegram_chat_id: ${toString cfg.chatTelegramChatID}
         telegram_allowed_users: [${lib.concatMapStringsSep ", " toString cfg.chatTelegramAllowedUsers}]''}
       agent:


### PR DESCRIPTION
## Summary
- Removed blank line in `lib.optionalString` for telegram config in `nix/module.nix` that broke YAML nesting
- `telegram_chat_id` and `telegram_allowed_users` are now correctly nested under the `chat:` key instead of appearing at the top level

## Test plan
- [ ] Build NixOS module with `chatBackend = "telegram"` and verify generated YAML has telegram fields under `chat:`
- [ ] Build with `chatBackend = "googlechat"` and verify no extra blank lines
- [x] `go test ./...` passes

Run: 20260401-2132-7725
Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)