### PR TITLE
feat: add update_series_monitoring tool for toggling season monitoring

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,6 +28,7 @@ Your capabilities:
 - Monitor system health and report any issues
 - Remove failed downloads and manage the blocklist
 - Get detailed series info and episode status
+- Update season monitoring settings (enable/disable monitoring per season)
 - Search for available releases and see why they were accepted/rejected
 - View Sonarr logs for debugging
 - Check quality profiles, blocklist, root folders, and download client status
@@ -379,6 +380,28 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 
 	case "get_download_clients":
 		result, err = a.sonarr.GetDownloadClients(ctx)
+
+	case "update_series_monitoring":
+		var input updateSeriesMonitoringInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true
+		}
+		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
+		if getErr != nil {
+			return jsonError(getErr.Error()), true
+		}
+		found := false
+		for i, s := range series.Seasons {
+			if s.SeasonNumber == input.SeasonNumber {
+				series.Seasons[i].Monitored = input.Monitored
+				found = true
+				break
+			}
+		}
+		if !found {
+			return jsonError(fmt.Sprintf("season %d not found in series %q", input.SeasonNumber, series.Title)), true
+		}
+		result, err = a.sonarr.UpdateSeries(ctx, series)
 
 	case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie":
 		if a.radarr == nil {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -76,6 +76,9 @@ func (m *mockSonarr) GetRootFolders(_ context.Context) ([]sonarr.RootFolder, err
 func (m *mockSonarr) GetDownloadClients(_ context.Context) ([]sonarr.DownloadClient, error) {
 	return m.downloadClientsResult, nil
 }
+func (m *mockSonarr) UpdateSeries(_ context.Context, series *sonarr.Series) (*sonarr.Series, error) {
+	return series, nil
+}
 
 // mockRadarr implements radarr.Client for agent testing.
 type mockRadarr struct {

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -46,6 +46,12 @@ type getBlocklistInput struct {
 	PageSize int `json:"page_size,omitempty" jsonschema_description:"Number of blocklist records to return"`
 }
 
+type updateSeriesMonitoringInput struct {
+	SeriesID     int  `json:"series_id" jsonschema_description:"Sonarr series ID"`
+	SeasonNumber int  `json:"season_number" jsonschema_description:"Season number to update monitoring for"`
+	Monitored    bool `json:"monitored" jsonschema_description:"Whether to enable (true) or disable (false) monitoring"`
+}
+
 type searchMoviesInput struct {
 	Term string `json:"term" jsonschema_description:"The search term to look up movies"`
 }
@@ -133,8 +139,9 @@ type toolDef struct {
 
 // destructiveTools is the set of tools that modify state.
 var destructiveTools = map[string]bool{
-	"add_series":          true,
-	"remove_failed":       true,
+	"add_series":                 true,
+	"remove_failed":              true,
+	"update_series_monitoring":   true,
 	"add_movie":           true,
 	"remove_failed_movie": true,
 	"approve_request":     true,
@@ -258,6 +265,14 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("List configured download clients with their status, protocol, and priority."),
 				InputSchema: generateSchema[struct{}](),
 			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "update_series_monitoring",
+				Description: anthropic.String("Enable or disable monitoring for a specific season of a series. Use get_series_detail first to find the series ID."),
+				InputSchema: generateSchema[updateSeriesMonitoringInput](),
+			},
+			Destructive: true,
 		},
 	}
 }

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -53,6 +53,9 @@ func (m *mockSonarr) GetRootFolders(_ context.Context) ([]sonarr.RootFolder, err
 func (m *mockSonarr) GetDownloadClients(_ context.Context) ([]sonarr.DownloadClient, error) {
 	return nil, nil
 }
+func (m *mockSonarr) UpdateSeries(_ context.Context, series *sonarr.Series) (*sonarr.Series, error) {
+	return series, nil
+}
 
 // mockNotifier records sent messages.
 type mockNotifier struct {

--- a/internal/sonarr/client.go
+++ b/internal/sonarr/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	GetBlocklist(ctx context.Context, pageSize int) (*BlocklistPage, error)
 	GetRootFolders(ctx context.Context) ([]RootFolder, error)
 	GetDownloadClients(ctx context.Context) ([]DownloadClient, error)
+	UpdateSeries(ctx context.Context, series *Series) (*Series, error)
 }
 
 // HTTPClient implements Client using Sonarr's v3 REST API.
@@ -224,6 +225,21 @@ func (c *HTTPClient) GetDownloadClients(ctx context.Context) ([]DownloadClient, 
 	return result, nil
 }
 
+func (c *HTTPClient) UpdateSeries(ctx context.Context, series *Series) (*Series, error) {
+	u := c.url(fmt.Sprintf("/api/v3/series/%d", series.ID))
+
+	body, err := json.Marshal(series)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update series: %w", err)
+	}
+
+	var result Series
+	if err := c.put(ctx, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("update series: %w", err)
+	}
+	return &result, nil
+}
+
 func (c *HTTPClient) url(path string) *url.URL {
 	u, err := url.Parse(c.baseURL + path)
 	if err != nil {
@@ -242,6 +258,15 @@ func (c *HTTPClient) get(ctx context.Context, rawURL string, out any) error {
 
 func (c *HTTPClient) post(ctx context.Context, rawURL string, body []byte, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.do(req, out)
+}
+
+func (c *HTTPClient) put(ctx context.Context, rawURL string, body []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, rawURL, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/internal/sonarr/client_test.go
+++ b/internal/sonarr/client_test.go
@@ -344,6 +344,49 @@ func TestGetDownloadClients(t *testing.T) {
 	}
 }
 
+func TestUpdateSeries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/series/1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var s Series
+		json.NewDecoder(r.Body).Decode(&s)
+		if len(s.Seasons) != 2 {
+			t.Fatalf("expected 2 seasons, got %d", len(s.Seasons))
+		}
+		if !s.Seasons[1].Monitored {
+			t.Errorf("expected season 2 to be monitored")
+		}
+
+		json.NewEncoder(w).Encode(s)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	series := &Series{
+		ID:    1,
+		Title: "Breaking Bad",
+		Seasons: []Season{
+			{SeasonNumber: 1, Monitored: true},
+			{SeasonNumber: 2, Monitored: true},
+		},
+	}
+	updated, err := client.UpdateSeries(context.Background(), series)
+	if err != nil {
+		t.Fatalf("UpdateSeries() error: %v", err)
+	}
+	if updated.Title != "Breaking Bad" {
+		t.Errorf("Title = %q, want %q", updated.Title, "Breaking Bad")
+	}
+	if len(updated.Seasons) != 2 {
+		t.Errorf("expected 2 seasons, got %d", len(updated.Seasons))
+	}
+}
+
 func TestHistory(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v3/history" {

--- a/internal/sonarr/types.go
+++ b/internal/sonarr/types.go
@@ -1,20 +1,26 @@
 package sonarr
 
+type Season struct {
+	SeasonNumber int  `json:"seasonNumber"`
+	Monitored    bool `json:"monitored"`
+}
+
 type Series struct {
-	ID               int    `json:"id"`
-	Title            string `json:"title"`
-	Year             int    `json:"year"`
-	TVDBID           int    `json:"tvdbId"`
-	Status           string `json:"status"`
-	Overview         string `json:"overview"`
-	Monitored        bool   `json:"monitored"`
-	SeasonCount      int    `json:"seasonCount"`
-	EpisodeCount     int    `json:"episodeCount,omitempty"`
-	EpisodeFileCount int    `json:"episodeFileCount,omitempty"`
-	SizeOnDisk       int64  `json:"sizeOnDisk,omitempty"`
-	RootFolderPath   string `json:"rootFolderPath"`
-	Path             string `json:"path,omitempty"`
-	QualityProfileID int    `json:"qualityProfileId"`
+	ID               int      `json:"id"`
+	Title            string   `json:"title"`
+	Year             int      `json:"year"`
+	TVDBID           int      `json:"tvdbId"`
+	Status           string   `json:"status"`
+	Overview         string   `json:"overview"`
+	Monitored        bool     `json:"monitored"`
+	SeasonCount      int      `json:"seasonCount"`
+	Seasons          []Season `json:"seasons,omitempty"`
+	EpisodeCount     int      `json:"episodeCount,omitempty"`
+	EpisodeFileCount int      `json:"episodeFileCount,omitempty"`
+	SizeOnDisk       int64    `json:"sizeOnDisk,omitempty"`
+	RootFolderPath   string   `json:"rootFolderPath"`
+	Path             string   `json:"path,omitempty"`
+	QualityProfileID int      `json:"qualityProfileId"`
 }
 
 type AddSeriesRequest struct {


### PR DESCRIPTION
## Summary
- Adds `update_series_monitoring` agent tool that enables/disables monitoring for a specific season of a series via the Sonarr v3 API (GET then PUT `/api/v3/series/{id}`)
- Adds `Season` struct and `Seasons` field to the `Series` type, `put()` HTTP helper, and `UpdateSeries` client method
- Tool is marked as destructive for rate limiting; validates the target season exists before updating

## Test plan
- [x] `TestUpdateSeries` covers the new client method with httptest
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Mock implementations updated in agent and monitor test packages

Run: 20260403-1802-3400