### PR TITLE
feat: add Sonarr write tools for search, deletion, and release grabbing

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -416,10 +416,7 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			cmd.Name = "SeasonSearch"
 			cmd.SeasonNumber = input.SeasonNumber
 		}
-		err = a.sonarr.Command(ctx, cmd)
-		if err == nil {
-			result = map[string]string{"status": "search triggered"}
-		}
+		result, err = a.sonarr.Command(ctx, cmd)
 
 	case "delete_series":
 		var input deleteSeriesInput
@@ -446,10 +443,7 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 		if err := json.Unmarshal(rawInput, &input); err != nil {
 			return jsonError("invalid input: " + err.Error()), true
 		}
-		err = a.sonarr.GrabRelease(ctx, input.GUID, input.IndexerID)
-		if err == nil {
-			result = map[string]string{"status": "grabbed"}
-		}
+		result, err = a.sonarr.GrabRelease(ctx, input.GUID, input.IndexerID)
 
 	case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie":
 		if a.radarr == nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -403,6 +403,54 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 		}
 		result, err = a.sonarr.UpdateSeries(ctx, series)
 
+	case "trigger_series_search":
+		var input triggerSeriesSearchInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true
+		}
+		cmd := sonarr.CommandRequest{
+			Name:     "SeriesSearch",
+			SeriesID: input.SeriesID,
+		}
+		if input.SeasonNumber != nil {
+			cmd.Name = "SeasonSearch"
+			cmd.SeasonNumber = input.SeasonNumber
+		}
+		err = a.sonarr.Command(ctx, cmd)
+		if err == nil {
+			result = map[string]string{"status": "search triggered"}
+		}
+
+	case "delete_series":
+		var input deleteSeriesInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true
+		}
+		err = a.sonarr.DeleteSeries(ctx, input.SeriesID, input.DeleteFiles)
+		if err == nil {
+			result = map[string]string{"status": "deleted"}
+		}
+
+	case "remove_blocklist_item":
+		var input removeBlocklistItemInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true
+		}
+		err = a.sonarr.DeleteBlocklistItem(ctx, input.ID)
+		if err == nil {
+			result = map[string]string{"status": "removed"}
+		}
+
+	case "grab_release":
+		var input grabReleaseInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true
+		}
+		err = a.sonarr.GrabRelease(ctx, input.GUID, input.IndexerID)
+		if err == nil {
+			result = map[string]string{"status": "grabbed"}
+		}
+
 	case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie":
 		if a.radarr == nil {
 			return jsonError("Radarr integration is not configured"), true

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -79,10 +79,14 @@ func (m *mockSonarr) GetDownloadClients(_ context.Context) ([]sonarr.DownloadCli
 func (m *mockSonarr) UpdateSeries(_ context.Context, series *sonarr.Series) (*sonarr.Series, error) {
 	return series, nil
 }
-func (m *mockSonarr) Command(_ context.Context, _ sonarr.CommandRequest) error { return nil }
-func (m *mockSonarr) DeleteSeries(_ context.Context, _ int, _ bool) error      { return nil }
-func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error        { return nil }
-func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) error      { return nil }
+func (m *mockSonarr) Command(_ context.Context, _ sonarr.CommandRequest) (*sonarr.CommandResource, error) {
+	return &sonarr.CommandResource{}, nil
+}
+func (m *mockSonarr) DeleteSeries(_ context.Context, _ int, _ bool) error { return nil }
+func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error  { return nil }
+func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) (*sonarr.Release, error) {
+	return &sonarr.Release{}, nil
+}
 
 // mockRadarr implements radarr.Client for agent testing.
 type mockRadarr struct {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -79,6 +79,10 @@ func (m *mockSonarr) GetDownloadClients(_ context.Context) ([]sonarr.DownloadCli
 func (m *mockSonarr) UpdateSeries(_ context.Context, series *sonarr.Series) (*sonarr.Series, error) {
 	return series, nil
 }
+func (m *mockSonarr) Command(_ context.Context, _ sonarr.CommandRequest) error { return nil }
+func (m *mockSonarr) DeleteSeries(_ context.Context, _ int, _ bool) error      { return nil }
+func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error        { return nil }
+func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) error      { return nil }
 
 // mockRadarr implements radarr.Client for agent testing.
 type mockRadarr struct {

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -52,6 +52,25 @@ type updateSeriesMonitoringInput struct {
 	Monitored    bool `json:"monitored" jsonschema_description:"Whether to enable (true) or disable (false) monitoring"`
 }
 
+type triggerSeriesSearchInput struct {
+	SeriesID     int  `json:"series_id" jsonschema_description:"Sonarr series ID to search for"`
+	SeasonNumber *int `json:"season_number,omitempty" jsonschema_description:"Season number to search. If omitted, searches the entire series."`
+}
+
+type deleteSeriesInput struct {
+	SeriesID    int  `json:"series_id" jsonschema_description:"Sonarr series ID to delete"`
+	DeleteFiles bool `json:"delete_files,omitempty" jsonschema_description:"Whether to delete the series files from disk (default false)"`
+}
+
+type removeBlocklistItemInput struct {
+	ID int `json:"id" jsonschema_description:"Blocklist item ID to remove"`
+}
+
+type grabReleaseInput struct {
+	GUID      string `json:"guid" jsonschema_description:"Release GUID from manual_search results"`
+	IndexerID int    `json:"indexer_id" jsonschema_description:"Indexer ID from manual_search results"`
+}
+
 type searchMoviesInput struct {
 	Term string `json:"term" jsonschema_description:"The search term to look up movies"`
 }
@@ -139,15 +158,19 @@ type toolDef struct {
 
 // destructiveTools is the set of tools that modify state.
 var destructiveTools = map[string]bool{
-	"add_series":                 true,
-	"remove_failed":              true,
-	"update_series_monitoring":   true,
-	"add_movie":           true,
-	"remove_failed_movie": true,
-	"approve_request":     true,
-	"decline_request":     true,
-	"notebook_write":      true,
-	"notebook_delete":     true,
+	"add_series":                true,
+	"remove_failed":             true,
+	"update_series_monitoring":  true,
+	"trigger_series_search":     true,
+	"delete_series":             true,
+	"remove_blocklist_item":     true,
+	"grab_release":              true,
+	"add_movie":                 true,
+	"remove_failed_movie":       true,
+	"approve_request":           true,
+	"decline_request":           true,
+	"notebook_write":            true,
+	"notebook_delete":           true,
 }
 
 // IsDestructive reports whether the named tool modifies state.
@@ -271,6 +294,38 @@ func sonarrToolDefs() []toolDef {
 				Name:        "update_series_monitoring",
 				Description: anthropic.String("Enable or disable monitoring for a specific season of a series. Use get_series_detail first to find the series ID."),
 				InputSchema: generateSchema[updateSeriesMonitoringInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "trigger_series_search",
+				Description: anthropic.String("Trigger a search for downloads for a series or a specific season. Sonarr will search indexers and automatically grab matching releases."),
+				InputSchema: generateSchema[triggerSeriesSearchInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "delete_series",
+				Description: anthropic.String("Delete a series from Sonarr. Optionally delete the series files from disk."),
+				InputSchema: generateSchema[deleteSeriesInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "remove_blocklist_item",
+				Description: anthropic.String("Remove an item from the blocklist, allowing Sonarr to download that release again."),
+				InputSchema: generateSchema[removeBlocklistItemInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "grab_release",
+				Description: anthropic.String("Download a specific release found via manual_search. Requires the GUID and indexer ID from the search results."),
+				InputSchema: generateSchema[grabReleaseInput](),
 			},
 			Destructive: true,
 		},

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -56,6 +56,10 @@ func (m *mockSonarr) GetDownloadClients(_ context.Context) ([]sonarr.DownloadCli
 func (m *mockSonarr) UpdateSeries(_ context.Context, series *sonarr.Series) (*sonarr.Series, error) {
 	return series, nil
 }
+func (m *mockSonarr) Command(_ context.Context, _ sonarr.CommandRequest) error { return nil }
+func (m *mockSonarr) DeleteSeries(_ context.Context, _ int, _ bool) error     { return nil }
+func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error       { return nil }
+func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) error     { return nil }
 
 // mockNotifier records sent messages.
 type mockNotifier struct {

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -56,10 +56,14 @@ func (m *mockSonarr) GetDownloadClients(_ context.Context) ([]sonarr.DownloadCli
 func (m *mockSonarr) UpdateSeries(_ context.Context, series *sonarr.Series) (*sonarr.Series, error) {
 	return series, nil
 }
-func (m *mockSonarr) Command(_ context.Context, _ sonarr.CommandRequest) error { return nil }
-func (m *mockSonarr) DeleteSeries(_ context.Context, _ int, _ bool) error     { return nil }
-func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error       { return nil }
-func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) error     { return nil }
+func (m *mockSonarr) Command(_ context.Context, _ sonarr.CommandRequest) (*sonarr.CommandResource, error) {
+	return &sonarr.CommandResource{}, nil
+}
+func (m *mockSonarr) DeleteSeries(_ context.Context, _ int, _ bool) error { return nil }
+func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error  { return nil }
+func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) (*sonarr.Release, error) {
+	return &sonarr.Release{}, nil
+}
 
 // mockNotifier records sent messages.
 type mockNotifier struct {

--- a/internal/sonarr/client.go
+++ b/internal/sonarr/client.go
@@ -28,10 +28,10 @@ type Client interface {
 	GetRootFolders(ctx context.Context) ([]RootFolder, error)
 	GetDownloadClients(ctx context.Context) ([]DownloadClient, error)
 	UpdateSeries(ctx context.Context, series *Series) (*Series, error)
-	Command(ctx context.Context, cmd CommandRequest) error
+	Command(ctx context.Context, cmd CommandRequest) (*CommandResource, error)
 	DeleteSeries(ctx context.Context, seriesID int, deleteFiles bool) error
 	DeleteBlocklistItem(ctx context.Context, id int) error
-	GrabRelease(ctx context.Context, guid string, indexerID int) error
+	GrabRelease(ctx context.Context, guid string, indexerID int) (*Release, error)
 }
 
 // HTTPClient implements Client using Sonarr's v3 REST API.
@@ -244,18 +244,19 @@ func (c *HTTPClient) UpdateSeries(ctx context.Context, series *Series) (*Series,
 	return &result, nil
 }
 
-func (c *HTTPClient) Command(ctx context.Context, cmd CommandRequest) error {
+func (c *HTTPClient) Command(ctx context.Context, cmd CommandRequest) (*CommandResource, error) {
 	u := c.url("/api/v3/command")
 
 	body, err := json.Marshal(cmd)
 	if err != nil {
-		return fmt.Errorf("marshal command request: %w", err)
+		return nil, fmt.Errorf("marshal command request: %w", err)
 	}
 
-	if err := c.post(ctx, u.String(), body, nil); err != nil {
-		return fmt.Errorf("command %s: %w", cmd.Name, err)
+	var result CommandResource
+	if err := c.post(ctx, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("command %s: %w", cmd.Name, err)
 	}
-	return nil
+	return &result, nil
 }
 
 func (c *HTTPClient) DeleteSeries(ctx context.Context, seriesID int, deleteFiles bool) error {
@@ -279,18 +280,19 @@ func (c *HTTPClient) DeleteBlocklistItem(ctx context.Context, id int) error {
 	return nil
 }
 
-func (c *HTTPClient) GrabRelease(ctx context.Context, guid string, indexerID int) error {
+func (c *HTTPClient) GrabRelease(ctx context.Context, guid string, indexerID int) (*Release, error) {
 	u := c.url("/api/v3/release")
 
 	body, err := json.Marshal(GrabReleaseRequest{GUID: guid, IndexerID: indexerID})
 	if err != nil {
-		return fmt.Errorf("marshal grab release request: %w", err)
+		return nil, fmt.Errorf("marshal grab release request: %w", err)
 	}
 
-	if err := c.post(ctx, u.String(), body, nil); err != nil {
-		return fmt.Errorf("grab release: %w", err)
+	var result Release
+	if err := c.post(ctx, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("grab release: %w", err)
 	}
-	return nil
+	return &result, nil
 }
 
 func (c *HTTPClient) url(path string) *url.URL {

--- a/internal/sonarr/client.go
+++ b/internal/sonarr/client.go
@@ -28,6 +28,10 @@ type Client interface {
 	GetRootFolders(ctx context.Context) ([]RootFolder, error)
 	GetDownloadClients(ctx context.Context) ([]DownloadClient, error)
 	UpdateSeries(ctx context.Context, series *Series) (*Series, error)
+	Command(ctx context.Context, cmd CommandRequest) error
+	DeleteSeries(ctx context.Context, seriesID int, deleteFiles bool) error
+	DeleteBlocklistItem(ctx context.Context, id int) error
+	GrabRelease(ctx context.Context, guid string, indexerID int) error
 }
 
 // HTTPClient implements Client using Sonarr's v3 REST API.
@@ -238,6 +242,55 @@ func (c *HTTPClient) UpdateSeries(ctx context.Context, series *Series) (*Series,
 		return nil, fmt.Errorf("update series: %w", err)
 	}
 	return &result, nil
+}
+
+func (c *HTTPClient) Command(ctx context.Context, cmd CommandRequest) error {
+	u := c.url("/api/v3/command")
+
+	body, err := json.Marshal(cmd)
+	if err != nil {
+		return fmt.Errorf("marshal command request: %w", err)
+	}
+
+	if err := c.post(ctx, u.String(), body, nil); err != nil {
+		return fmt.Errorf("command %s: %w", cmd.Name, err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) DeleteSeries(ctx context.Context, seriesID int, deleteFiles bool) error {
+	u := c.url(fmt.Sprintf("/api/v3/series/%d", seriesID))
+	q := u.Query()
+	q.Set("deleteFiles", strconv.FormatBool(deleteFiles))
+	u.RawQuery = q.Encode()
+
+	if err := c.delete(ctx, u.String()); err != nil {
+		return fmt.Errorf("delete series: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) DeleteBlocklistItem(ctx context.Context, id int) error {
+	u := c.url(fmt.Sprintf("/api/v3/blocklist/%d", id))
+
+	if err := c.delete(ctx, u.String()); err != nil {
+		return fmt.Errorf("delete blocklist item: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) GrabRelease(ctx context.Context, guid string, indexerID int) error {
+	u := c.url("/api/v3/release")
+
+	body, err := json.Marshal(GrabReleaseRequest{GUID: guid, IndexerID: indexerID})
+	if err != nil {
+		return fmt.Errorf("marshal grab release request: %w", err)
+	}
+
+	if err := c.post(ctx, u.String(), body, nil); err != nil {
+		return fmt.Errorf("grab release: %w", err)
+	}
+	return nil
 }
 
 func (c *HTTPClient) url(path string) *url.URL {

--- a/internal/sonarr/client_test.go
+++ b/internal/sonarr/client_test.go
@@ -431,14 +431,27 @@ func TestCommand(t *testing.T) {
 			t.Errorf("SeriesID = %d, want 5", cmd.SeriesID)
 		}
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("{}"))
+		json.NewEncoder(w).Encode(CommandResource{
+			ID:     42,
+			Name:   "SeriesSearch",
+			Status: "queued",
+		})
 	}))
 	defer srv.Close()
 
 	client := NewClient(srv.URL, "test-key")
-	err := client.Command(context.Background(), CommandRequest{Name: "SeriesSearch", SeriesID: 5})
+	res, err := client.Command(context.Background(), CommandRequest{Name: "SeriesSearch", SeriesID: 5})
 	if err != nil {
 		t.Fatalf("Command() error: %v", err)
+	}
+	if res.ID != 42 {
+		t.Errorf("ID = %d, want 42", res.ID)
+	}
+	if res.Name != "SeriesSearch" {
+		t.Errorf("Name = %q, want SeriesSearch", res.Name)
+	}
+	if res.Status != "queued" {
+		t.Errorf("Status = %q, want queued", res.Status)
 	}
 }
 
@@ -500,13 +513,23 @@ func TestGrabRelease(t *testing.T) {
 			t.Errorf("IndexerID = %d, want 2", req.IndexerID)
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("{}"))
+		json.NewEncoder(w).Encode(Release{
+			GUID:      "abc-123",
+			IndexerID: 2,
+			Title:     "Test.Release.S01E01.720p",
+		})
 	}))
 	defer srv.Close()
 
 	client := NewClient(srv.URL, "test-key")
-	err := client.GrabRelease(context.Background(), "abc-123", 2)
+	rel, err := client.GrabRelease(context.Background(), "abc-123", 2)
 	if err != nil {
 		t.Fatalf("GrabRelease() error: %v", err)
+	}
+	if rel.GUID != "abc-123" {
+		t.Errorf("GUID = %q, want abc-123", rel.GUID)
+	}
+	if rel.Title != "Test.Release.S01E01.720p" {
+		t.Errorf("Title = %q, want Test.Release.S01E01.720p", rel.Title)
 	}
 }

--- a/internal/sonarr/client_test.go
+++ b/internal/sonarr/client_test.go
@@ -413,3 +413,100 @@ func TestHistory(t *testing.T) {
 		t.Errorf("TotalRecords = %d, want 1", history.TotalRecords)
 	}
 }
+
+func TestCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/command" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var cmd CommandRequest
+		json.NewDecoder(r.Body).Decode(&cmd)
+		if cmd.Name != "SeriesSearch" {
+			t.Errorf("Name = %q, want SeriesSearch", cmd.Name)
+		}
+		if cmd.SeriesID != 5 {
+			t.Errorf("SeriesID = %d, want 5", cmd.SeriesID)
+		}
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.Command(context.Background(), CommandRequest{Name: "SeriesSearch", SeriesID: 5})
+	if err != nil {
+		t.Fatalf("Command() error: %v", err)
+	}
+}
+
+func TestDeleteSeries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/series/7" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("deleteFiles") != "true" {
+			t.Errorf("deleteFiles = %s, want true", r.URL.Query().Get("deleteFiles"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.DeleteSeries(context.Background(), 7, true)
+	if err != nil {
+		t.Fatalf("DeleteSeries() error: %v", err)
+	}
+}
+
+func TestDeleteBlocklistItem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/blocklist/99" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.DeleteBlocklistItem(context.Background(), 99)
+	if err != nil {
+		t.Fatalf("DeleteBlocklistItem() error: %v", err)
+	}
+}
+
+func TestGrabRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/release" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var req GrabReleaseRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.GUID != "abc-123" {
+			t.Errorf("GUID = %q, want abc-123", req.GUID)
+		}
+		if req.IndexerID != 2 {
+			t.Errorf("IndexerID = %d, want 2", req.IndexerID)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.GrabRelease(context.Background(), "abc-123", 2)
+	if err != nil {
+		t.Fatalf("GrabRelease() error: %v", err)
+	}
+}

--- a/internal/sonarr/types.go
+++ b/internal/sonarr/types.go
@@ -96,6 +96,8 @@ type LogPage struct {
 }
 
 type Release struct {
+	GUID       string   `json:"guid"`
+	IndexerID  int      `json:"indexerId"`
 	Title      string   `json:"title"`
 	Indexer    string   `json:"indexer"`
 	Quality    string   `json:"quality"`
@@ -134,4 +136,15 @@ type DownloadClient struct {
 	Enable   bool   `json:"enable"`
 	Protocol string `json:"protocol"`
 	Priority int    `json:"priority"`
+}
+
+type CommandRequest struct {
+	Name         string `json:"name"`
+	SeriesID     int    `json:"seriesId,omitempty"`
+	SeasonNumber *int   `json:"seasonNumber,omitempty"`
+}
+
+type GrabReleaseRequest struct {
+	GUID      string `json:"guid"`
+	IndexerID int    `json:"indexerId"`
 }

--- a/internal/sonarr/types.go
+++ b/internal/sonarr/types.go
@@ -144,6 +144,18 @@ type CommandRequest struct {
 	SeasonNumber *int   `json:"seasonNumber,omitempty"`
 }
 
+type CommandResource struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Queued    string `json:"queued,omitempty"`
+	Started   string `json:"started,omitempty"`
+	Ended     string `json:"ended,omitempty"`
+	Priority  string `json:"priority,omitempty"`
+	Trigger   string `json:"trigger,omitempty"`
+	SendUpdatesToClient bool `json:"sendUpdatesToClient"`
+}
+
 type GrabReleaseRequest struct {
 	GUID      string `json:"guid"`
 	IndexerID int    `json:"indexerId"`


### PR DESCRIPTION
## Summary
- Add four new destructive Sonarr agent tools: `trigger_series_search`, `delete_series`, `remove_blocklist_item`, and `grab_release`
- Add corresponding Sonarr client methods: `Command`, `DeleteSeries`, `DeleteBlocklistItem`, `GrabRelease`
- Add `GUID` and `IndexerID` fields to `Release` type so `manual_search` results can feed into `grab_release`

## Test plan
- [x] All new client methods have httptest-based integration tests
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (including updated mocks in agent and monitor tests)

Run: 20260403-1805-af5f