### PR TITLE
feat: add Prowlarr indexer management tools

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,7 +32,7 @@ Your capabilities:
 - Search for available releases and see why they were accepted/rejected
 - View Sonarr logs for debugging
 - Check quality profiles, blocklist, root folders, and download client status
-- Manage indexers via Prowlarr: list, test, check stats and health, search across indexers
+- Manage indexers via Prowlarr: list, test, enable/disable, update priority, delete, check stats and health, search across indexers
 - List, approve, and decline media requests from Overseerr
 - Search for movies and TV shows in Overseerr's media database
 - Get request statistics (pending, approved, declined counts)
@@ -498,7 +498,7 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			}
 		}
 
-	case "list_indexers", "test_indexer", "get_indexer_stats", "check_indexer_health", "search_indexers":
+	case "list_indexers", "test_indexer", "test_all_indexers", "get_indexer_stats", "check_indexer_health", "search_indexers", "enable_indexer", "update_indexer_priority", "delete_indexer":
 		if a.prowlarr == nil {
 			return jsonError("Prowlarr integration is not configured"), true
 		}
@@ -514,6 +514,8 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			if err == nil {
 				result = map[string]string{"status": "ok"}
 			}
+		case "test_all_indexers":
+			result, err = a.prowlarr.TestAllIndexers(ctx)
 		case "get_indexer_stats":
 			result, err = a.prowlarr.GetIndexerStats(ctx)
 		case "check_indexer_health":
@@ -524,6 +526,57 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 				return jsonError("invalid input: " + err.Error()), true
 			}
 			result, err = a.prowlarr.Search(ctx, input.Query)
+		case "enable_indexer":
+			var input enableIndexerInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			indexers, listErr := a.prowlarr.ListIndexers(ctx)
+			if listErr != nil {
+				return jsonError(listErr.Error()), true
+			}
+			var found *prowlarr.Indexer
+			for i := range indexers {
+				if indexers[i].ID == input.IndexerID {
+					found = &indexers[i]
+					break
+				}
+			}
+			if found == nil {
+				return jsonError(fmt.Sprintf("indexer %d not found", input.IndexerID)), true
+			}
+			found.Enable = input.Enabled
+			result, err = a.prowlarr.UpdateIndexer(ctx, found)
+		case "update_indexer_priority":
+			var input updateIndexerPriorityInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			indexers, listErr := a.prowlarr.ListIndexers(ctx)
+			if listErr != nil {
+				return jsonError(listErr.Error()), true
+			}
+			var found *prowlarr.Indexer
+			for i := range indexers {
+				if indexers[i].ID == input.IndexerID {
+					found = &indexers[i]
+					break
+				}
+			}
+			if found == nil {
+				return jsonError(fmt.Sprintf("indexer %d not found", input.IndexerID)), true
+			}
+			found.Priority = input.Priority
+			result, err = a.prowlarr.UpdateIndexer(ctx, found)
+		case "delete_indexer":
+			var input deleteIndexerInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			err = a.prowlarr.DeleteIndexer(ctx, input.IndexerID)
+			if err == nil {
+				result = map[string]string{"status": "deleted"}
+			}
 		}
 
 	case "list_requests", "approve_request", "decline_request", "get_request_count", "search_media":

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -531,19 +531,9 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			if err := json.Unmarshal(rawInput, &input); err != nil {
 				return jsonError("invalid input: " + err.Error()), true
 			}
-			indexers, listErr := a.prowlarr.ListIndexers(ctx)
-			if listErr != nil {
-				return jsonError(listErr.Error()), true
-			}
-			var found *prowlarr.Indexer
-			for i := range indexers {
-				if indexers[i].ID == input.IndexerID {
-					found = &indexers[i]
-					break
-				}
-			}
-			if found == nil {
-				return jsonError(fmt.Sprintf("indexer %d not found", input.IndexerID)), true
+			found, errStr := a.findIndexer(ctx, input.IndexerID)
+			if errStr != "" {
+				return errStr, true
 			}
 			found.Enable = input.Enabled
 			result, err = a.prowlarr.UpdateIndexer(ctx, found)
@@ -552,19 +542,9 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			if err := json.Unmarshal(rawInput, &input); err != nil {
 				return jsonError("invalid input: " + err.Error()), true
 			}
-			indexers, listErr := a.prowlarr.ListIndexers(ctx)
-			if listErr != nil {
-				return jsonError(listErr.Error()), true
-			}
-			var found *prowlarr.Indexer
-			for i := range indexers {
-				if indexers[i].ID == input.IndexerID {
-					found = &indexers[i]
-					break
-				}
-			}
-			if found == nil {
-				return jsonError(fmt.Sprintf("indexer %d not found", input.IndexerID)), true
+			found, errStr := a.findIndexer(ctx, input.IndexerID)
+			if errStr != "" {
+				return errStr, true
 			}
 			found.Priority = input.Priority
 			result, err = a.prowlarr.UpdateIndexer(ctx, found)
@@ -715,6 +695,21 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 		return jsonError("failed to marshal result: " + marshalErr.Error()), true
 	}
 	return string(data), false
+}
+
+// findIndexer fetches the indexer list from Prowlarr and returns the indexer with the given ID.
+// On failure, it returns a non-empty JSON error string.
+func (a *Agent) findIndexer(ctx context.Context, id int) (*prowlarr.Indexer, string) {
+	indexers, err := a.prowlarr.ListIndexers(ctx)
+	if err != nil {
+		return nil, jsonError(err.Error())
+	}
+	for i := range indexers {
+		if indexers[i].ID == id {
+			return &indexers[i], ""
+		}
+	}
+	return nil, jsonError(fmt.Sprintf("indexer %d not found", id))
 }
 
 func jsonError(msg string) string {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -117,16 +117,30 @@ func (m *mockRadarr) RemoveFailed(_ context.Context, _ int, _ bool) error {
 
 // mockProwlarr implements prowlarr.Client for agent testing.
 type mockProwlarr struct {
-	indexers     []prowlarr.Indexer
-	stats        *prowlarr.IndexerStats
-	health       []prowlarr.HealthCheck
-	searchResult []prowlarr.SearchResult
+	indexers       []prowlarr.Indexer
+	stats          *prowlarr.IndexerStats
+	health         []prowlarr.HealthCheck
+	searchResult   []prowlarr.SearchResult
+	testAllResult  []prowlarr.IndexerTestResult
+	updatedIndexer *prowlarr.Indexer
+	deletedID      int
 }
 
 func (m *mockProwlarr) ListIndexers(_ context.Context) ([]prowlarr.Indexer, error) {
 	return m.indexers, nil
 }
 func (m *mockProwlarr) TestIndexer(_ context.Context, _ int) error {
+	return nil
+}
+func (m *mockProwlarr) TestAllIndexers(_ context.Context) ([]prowlarr.IndexerTestResult, error) {
+	return m.testAllResult, nil
+}
+func (m *mockProwlarr) UpdateIndexer(_ context.Context, indexer *prowlarr.Indexer) (*prowlarr.Indexer, error) {
+	m.updatedIndexer = indexer
+	return indexer, nil
+}
+func (m *mockProwlarr) DeleteIndexer(_ context.Context, id int) error {
+	m.deletedID = id
 	return nil
 }
 func (m *mockProwlarr) GetIndexerStats(_ context.Context) (*prowlarr.IndexerStats, error) {

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -100,6 +100,20 @@ type searchIndexersInput struct {
 	Query string `json:"query" jsonschema_description:"Search query to run across all indexers"`
 }
 
+type enableIndexerInput struct {
+	IndexerID int  `json:"indexer_id" jsonschema_description:"Indexer ID to enable or disable"`
+	Enabled   bool `json:"enabled" jsonschema_description:"Set to true to enable, false to disable"`
+}
+
+type updateIndexerPriorityInput struct {
+	IndexerID int `json:"indexer_id" jsonschema_description:"Indexer ID to update"`
+	Priority  int `json:"priority" jsonschema_description:"New priority value for the indexer"`
+}
+
+type deleteIndexerInput struct {
+	IndexerID int `json:"indexer_id" jsonschema_description:"Indexer ID to remove"`
+}
+
 type listRequestsInput struct {
 	Filter string `json:"filter,omitempty" jsonschema_description:"Filter requests by status: pending, approved, all (default all)"`
 	Take   int    `json:"take,omitempty" jsonschema_description:"Number of requests to return (default 20)"`
@@ -171,6 +185,9 @@ var destructiveTools = map[string]bool{
 	"decline_request":           true,
 	"notebook_write":            true,
 	"notebook_delete":           true,
+	"enable_indexer":            true,
+	"update_indexer_priority":   true,
+	"delete_indexer":            true,
 }
 
 // IsDestructive reports whether the named tool modifies state.
@@ -416,6 +433,37 @@ func prowlarrToolDefs() []toolDef {
 				Name:        "search_indexers",
 				Description: anthropic.String("Search across all configured indexers for releases matching a query."),
 				InputSchema: generateSchema[searchIndexersInput](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "enable_indexer",
+				Description: anthropic.String("Enable or disable a Prowlarr indexer."),
+				InputSchema: generateSchema[enableIndexerInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "update_indexer_priority",
+				Description: anthropic.String("Change the priority of a Prowlarr indexer."),
+				InputSchema: generateSchema[updateIndexerPriorityInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "delete_indexer",
+				Description: anthropic.String("Remove an indexer from Prowlarr."),
+				InputSchema: generateSchema[deleteIndexerInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "test_all_indexers",
+				Description: anthropic.String("Test all configured indexers at once."),
+				InputSchema: generateSchema[struct{}](),
 			},
 		},
 	}

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -15,6 +15,9 @@ import (
 type Client interface {
 	ListIndexers(ctx context.Context) ([]Indexer, error)
 	TestIndexer(ctx context.Context, id int) error
+	TestAllIndexers(ctx context.Context) ([]IndexerTestResult, error)
+	UpdateIndexer(ctx context.Context, indexer *Indexer) (*Indexer, error)
+	DeleteIndexer(ctx context.Context, indexerID int) error
 	GetIndexerStats(ctx context.Context) (*IndexerStats, error)
 	CheckHealth(ctx context.Context) ([]HealthCheck, error)
 	Search(ctx context.Context, query string) ([]SearchResult, error)
@@ -55,6 +58,40 @@ func (c *HTTPClient) TestIndexer(ctx context.Context, id int) error {
 
 	if err := c.post(ctx, u.String(), body, nil); err != nil {
 		return fmt.Errorf("test indexer: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) TestAllIndexers(ctx context.Context) ([]IndexerTestResult, error) {
+	u := c.url("/api/v1/indexer/testall")
+
+	var result []IndexerTestResult
+	if err := c.post(ctx, u.String(), []byte("{}"), &result); err != nil {
+		return nil, fmt.Errorf("test all indexers: %w", err)
+	}
+	return result, nil
+}
+
+func (c *HTTPClient) UpdateIndexer(ctx context.Context, indexer *Indexer) (*Indexer, error) {
+	u := c.url(fmt.Sprintf("/api/v1/indexer/%d", indexer.ID))
+
+	body, err := json.Marshal(indexer)
+	if err != nil {
+		return nil, fmt.Errorf("marshal indexer: %w", err)
+	}
+
+	var result Indexer
+	if err := c.put(ctx, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("update indexer: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *HTTPClient) DeleteIndexer(ctx context.Context, indexerID int) error {
+	u := c.url(fmt.Sprintf("/api/v1/indexer/%d", indexerID))
+
+	if err := c.delete(ctx, u.String()); err != nil {
+		return fmt.Errorf("delete indexer: %w", err)
 	}
 	return nil
 }
@@ -116,6 +153,23 @@ func (c *HTTPClient) post(ctx context.Context, rawURL string, body []byte, out a
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.do(req, out)
+}
+
+func (c *HTTPClient) put(ctx context.Context, rawURL string, body []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.do(req, out)
+}
+
+func (c *HTTPClient) delete(ctx context.Context, rawURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil)
 }
 
 func (c *HTTPClient) do(req *http.Request, out any) error {

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -144,6 +144,92 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+func TestTestAllIndexers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/indexer/testall" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]IndexerTestResult{
+			{ID: 1, IsValid: true},
+			{ID: 2, IsValid: false, Message: "connection refused"},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	results, err := client.TestAllIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("TestAllIndexers() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].IsValid {
+		t.Error("expected first indexer to be valid")
+	}
+	if results[1].IsValid {
+		t.Error("expected second indexer to be invalid")
+	}
+	if results[1].Message != "connection refused" {
+		t.Errorf("Message = %q, want %q", results[1].Message, "connection refused")
+	}
+}
+
+func TestUpdateIndexer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/indexer/3" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var idx Indexer
+		json.NewDecoder(r.Body).Decode(&idx)
+		if !idx.Enable {
+			t.Error("expected Enable to be true")
+		}
+		if idx.Priority != 10 {
+			t.Errorf("Priority = %d, want 10", idx.Priority)
+		}
+
+		json.NewEncoder(w).Encode(idx)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	indexer := &Indexer{ID: 3, Name: "Test", Enable: true, Priority: 10, Protocol: "torrent"}
+	result, err := client.UpdateIndexer(context.Background(), indexer)
+	if err != nil {
+		t.Fatalf("UpdateIndexer() error: %v", err)
+	}
+	if result.Name != "Test" {
+		t.Errorf("Name = %q, want %q", result.Name, "Test")
+	}
+}
+
+func TestDeleteIndexer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/indexer/7" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.DeleteIndexer(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("DeleteIndexer() error: %v", err)
+	}
+}
+
 func TestAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/prowlarr/types.go
+++ b/internal/prowlarr/types.go
@@ -50,7 +50,7 @@ type Category struct {
 }
 
 type IndexerTestResult struct {
-	ID      int    `json:"id"`
+	ID      int    `json:"indexerId"`
 	IsValid bool   `json:"isValid"`
 	Message string `json:"message,omitempty"`
 }

--- a/internal/prowlarr/types.go
+++ b/internal/prowlarr/types.go
@@ -48,3 +48,9 @@ type Category struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
+
+type IndexerTestResult struct {
+	ID      int    `json:"id"`
+	IsValid bool   `json:"isValid"`
+	Message string `json:"message,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Add `put()` and `delete()` HTTP methods to the Prowlarr client
- Add three new client methods: `UpdateIndexer`, `DeleteIndexer`, `TestAllIndexers`
- Add four new agent tools: `enable_indexer`, `update_indexer_priority`, `delete_indexer`, `test_all_indexers`
- All mutating tools marked destructive for rate limiting
- Add `IndexerTestResult` type for test-all responses

## Test plan
- [x] New Prowlarr client tests for UpdateIndexer, DeleteIndexer, TestAllIndexers
- [x] Existing mock updated to satisfy new interface methods
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

Run: 20260403-1806-e471