### PR TITLE
feat: add Overseerr request detail, deletion, and retry

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -33,7 +33,8 @@ Your capabilities:
 - View Sonarr logs for debugging
 - Check quality profiles, blocklist, root folders, and download client status
 - Manage indexers via Prowlarr: list, test, enable/disable, update priority, delete, check stats and health, search across indexers
-- List, approve, and decline media requests from Overseerr
+- List, approve, decline, delete, and retry media requests from Overseerr
+- Get detailed information about specific requests
 - Search for movies and TV shows in Overseerr's media database
 - Get request statistics (pending, approved, declined counts)
 
@@ -559,7 +560,7 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			}
 		}
 
-	case "list_requests", "approve_request", "decline_request", "get_request_count", "search_media":
+	case "list_requests", "approve_request", "decline_request", "get_request_detail", "delete_request", "retry_request", "get_request_count", "search_media":
 		if a.overseerr == nil {
 			return jsonError("Overseerr integration is not configured"), true
 		}
@@ -592,6 +593,27 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			if err == nil {
 				result = map[string]string{"status": "declined"}
 			}
+		case "get_request_detail":
+			var input getRequestDetailInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			result, err = a.overseerr.GetRequest(ctx, input.ID)
+		case "delete_request":
+			var input deleteRequestInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			err = a.overseerr.DeleteRequest(ctx, input.ID)
+			if err == nil {
+				result = map[string]string{"status": "deleted"}
+			}
+		case "retry_request":
+			var input retryRequestInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			result, err = a.overseerr.RetryRequest(ctx, input.ID)
 		case "get_request_count":
 			result, err = a.overseerr.GetRequestCount(ctx)
 		case "search_media":

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -172,6 +172,15 @@ func (m *mockOverseerr) DeclineRequest(_ context.Context, _ int) error {
 func (m *mockOverseerr) GetRequestCount(_ context.Context) (*overseerr.RequestCount, error) {
 	return m.requestCount, nil
 }
+func (m *mockOverseerr) GetRequest(_ context.Context, _ int) (*overseerr.Request, error) {
+	return nil, nil
+}
+func (m *mockOverseerr) DeleteRequest(_ context.Context, _ int) error {
+	return nil
+}
+func (m *mockOverseerr) RetryRequest(_ context.Context, _ int) (*overseerr.Request, error) {
+	return nil, nil
+}
 func (m *mockOverseerr) SearchMedia(_ context.Context, _ string, _ int) (*overseerr.SearchResults, error) {
 	return m.searchResult, nil
 }

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -128,6 +128,18 @@ type declineRequestInput struct {
 	ID int `json:"id" jsonschema_description:"Request ID to decline"`
 }
 
+type getRequestDetailInput struct {
+	ID int `json:"id" jsonschema_description:"Request ID to get details for"`
+}
+
+type deleteRequestInput struct {
+	ID int `json:"id" jsonschema_description:"Request ID to delete"`
+}
+
+type retryRequestInput struct {
+	ID int `json:"id" jsonschema_description:"Request ID to retry"`
+}
+
 type searchMediaInput struct {
 	Query string `json:"query" jsonschema_description:"Search query for movies or TV shows"`
 	Page  int    `json:"page,omitempty" jsonschema_description:"Page number for results (default 1)"`
@@ -172,22 +184,24 @@ type toolDef struct {
 
 // destructiveTools is the set of tools that modify state.
 var destructiveTools = map[string]bool{
-	"add_series":                true,
-	"remove_failed":             true,
-	"update_series_monitoring":  true,
-	"trigger_series_search":     true,
-	"delete_series":             true,
-	"remove_blocklist_item":     true,
-	"grab_release":              true,
-	"add_movie":                 true,
-	"remove_failed_movie":       true,
-	"approve_request":           true,
-	"decline_request":           true,
-	"notebook_write":            true,
-	"notebook_delete":           true,
-	"enable_indexer":            true,
-	"update_indexer_priority":   true,
-	"delete_indexer":            true,
+	"add_series":              true,
+	"remove_failed":           true,
+	"update_series_monitoring": true,
+	"trigger_series_search":   true,
+	"delete_series":           true,
+	"remove_blocklist_item":   true,
+	"grab_release":            true,
+	"add_movie":               true,
+	"remove_failed_movie":     true,
+	"approve_request":         true,
+	"decline_request":         true,
+	"delete_request":          true,
+	"retry_request":           true,
+	"notebook_write":          true,
+	"notebook_delete":         true,
+	"enable_indexer":           true,
+	"update_indexer_priority":  true,
+	"delete_indexer":           true,
 }
 
 // IsDestructive reports whether the named tool modifies state.
@@ -491,6 +505,29 @@ func overseerrToolDefs() []toolDef {
 				Name:        "decline_request",
 				Description: anthropic.String("Decline a pending media request in Overseerr."),
 				InputSchema: generateSchema[declineRequestInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "get_request_detail",
+				Description: anthropic.String("Get detailed information about a specific Overseerr media request."),
+				InputSchema: generateSchema[getRequestDetailInput](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "delete_request",
+				Description: anthropic.String("Delete a media request from Overseerr."),
+				InputSchema: generateSchema[deleteRequestInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "retry_request",
+				Description: anthropic.String("Retry a failed Overseerr media request."),
+				InputSchema: generateSchema[retryRequestInput](),
 			},
 			Destructive: true,
 		},

--- a/internal/overseerr/client.go
+++ b/internal/overseerr/client.go
@@ -15,8 +15,11 @@ import (
 // Client defines the operations available against an Overseerr instance.
 type Client interface {
 	ListRequests(ctx context.Context, filter string, take, skip int) (*RequestPage, error)
+	GetRequest(ctx context.Context, id int) (*Request, error)
 	ApproveRequest(ctx context.Context, id int) error
 	DeclineRequest(ctx context.Context, id int) error
+	DeleteRequest(ctx context.Context, id int) error
+	RetryRequest(ctx context.Context, id int) (*Request, error)
 	GetRequestCount(ctx context.Context) (*RequestCount, error)
 	SearchMedia(ctx context.Context, query string, page int) (*SearchResults, error)
 }
@@ -36,6 +39,35 @@ func NewClient(baseURL, apiKey string) *HTTPClient {
 			Timeout: 10 * time.Second,
 		},
 	}
+}
+
+func (c *HTTPClient) GetRequest(ctx context.Context, id int) (*Request, error) {
+	u := c.url(fmt.Sprintf("/api/v1/request/%d", id))
+
+	var result Request
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("get request: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *HTTPClient) DeleteRequest(ctx context.Context, id int) error {
+	u := c.url(fmt.Sprintf("/api/v1/request/%d", id))
+
+	if err := c.delete(ctx, u.String()); err != nil {
+		return fmt.Errorf("delete request: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) RetryRequest(ctx context.Context, id int) (*Request, error) {
+	u := c.url(fmt.Sprintf("/api/v1/request/%d/retry", id))
+
+	var result Request
+	if err := c.post(ctx, u.String(), nil, &result); err != nil {
+		return nil, fmt.Errorf("retry request: %w", err)
+	}
+	return &result, nil
 }
 
 func (c *HTTPClient) ListRequests(ctx context.Context, filter string, take, skip int) (*RequestPage, error) {
@@ -132,6 +164,14 @@ func (c *HTTPClient) post(ctx context.Context, rawURL string, body []byte, out a
 		req.Header.Set("Content-Type", "application/json")
 	}
 	return c.do(req, out)
+}
+
+func (c *HTTPClient) delete(ctx context.Context, rawURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil)
 }
 
 func (c *HTTPClient) do(req *http.Request, out any) error {

--- a/internal/overseerr/client_test.go
+++ b/internal/overseerr/client_test.go
@@ -144,6 +144,87 @@ func TestSearchMedia(t *testing.T) {
 	}
 }
 
+func TestGetRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/request/7" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(Request{
+			ID:     7,
+			Status: 2,
+			Type:   "movie",
+			Media:  MediaInfo{TMDBID: 603, MediaType: "movie"},
+			RequestedBy: UserInfo{DisplayName: "bob"},
+			CreatedAt:   "2026-01-01T00:00:00.000Z",
+			UpdatedAt:   "2026-01-02T00:00:00.000Z",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	req, err := client.GetRequest(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("GetRequest() error: %v", err)
+	}
+	if req.ID != 7 {
+		t.Errorf("ID = %d, want 7", req.ID)
+	}
+	if req.UpdatedAt != "2026-01-02T00:00:00.000Z" {
+		t.Errorf("UpdatedAt = %q, want %q", req.UpdatedAt, "2026-01-02T00:00:00.000Z")
+	}
+}
+
+func TestDeleteRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/request/42" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Api-Key") != "test-key" {
+			t.Errorf("missing or wrong API key header")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.DeleteRequest(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("DeleteRequest() error: %v", err)
+	}
+}
+
+func TestRetryRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/request/5/retry" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(Request{
+			ID:     5,
+			Status: 1,
+			Type:   "tv",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	req, err := client.RetryRequest(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("RetryRequest() error: %v", err)
+	}
+	if req.ID != 5 {
+		t.Errorf("ID = %d, want 5", req.ID)
+	}
+}
+
 func TestOverseerrAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/overseerr/types.go
+++ b/internal/overseerr/types.go
@@ -7,12 +7,22 @@ type Request struct {
 	Media       MediaInfo    `json:"media"`
 	RequestedBy UserInfo     `json:"requestedBy"`
 	CreatedAt   string       `json:"createdAt"`
+	UpdatedAt   string       `json:"updatedAt"`
+	Seasons     []SeasonInfo `json:"seasons,omitempty"`
 }
 
 type MediaInfo struct {
-	TMDBID int `json:"tmdbId"`
-	TVDBID int `json:"tvdbId"`
-	Status int `json:"status"`
+	TMDBID            int    `json:"tmdbId"`
+	TVDBID            int    `json:"tvdbId"`
+	Status            int    `json:"status"`
+	MediaType         string `json:"mediaType"`
+	ExternalServiceID int    `json:"externalServiceId,omitempty"`
+}
+
+type SeasonInfo struct {
+	ID           int `json:"id"`
+	SeasonNumber int `json:"seasonNumber"`
+	Status       int `json:"status"`
 }
 
 type UserInfo struct {


### PR DESCRIPTION
## Summary
- Add `GetRequest`, `DeleteRequest`, and `RetryRequest` to the Overseerr client with a new `delete()` HTTP helper
- Wire up three new agent tools: `get_request_detail`, `delete_request` (destructive), `retry_request` (destructive)
- Enrich the `Request` type with `UpdatedAt`, `Seasons`, and additional `MediaInfo` fields for the detail view
- Add httptest-based tests for all three new client methods

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new tests for GetRequest, DeleteRequest, RetryRequest)
- [x] `go vet ./...` clean

Run: 20260403-1806-d904