### PR TITLE
feat: bring Radarr client to full parity with Sonarr

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -533,13 +533,12 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 			if err := json.Unmarshal(rawInput, &input); err != nil {
 				return jsonError("invalid input: " + err.Error()), true
 			}
-			movie, getErr := a.radarr.GetMovie(ctx, input.MovieID)
-			if getErr != nil {
-				err = getErr
-			} else {
-				movie.Monitored = input.Monitored
-				result, err = a.radarr.UpdateMovie(ctx, movie)
+			movie, err := a.radarr.GetMovie(ctx, input.MovieID)
+			if err != nil {
+				break
 			}
+			movie.Monitored = input.Monitored
+			result, err = a.radarr.UpdateMovie(ctx, movie)
 		case "delete_movie":
 			var input deleteMovieInput
 			if err := json.Unmarshal(rawInput, &input); err != nil {
@@ -555,7 +554,7 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 				return jsonError("invalid input: " + err.Error()), true
 			}
 			err = a.radarr.Command(ctx, radarr.CommandRequest{
-				Name:     "MoviesSearch",
+				Name:     radarr.CommandMoviesSearch,
 				MovieIDs: []int{input.MovieID},
 			})
 			if err == nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -446,7 +446,10 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 		}
 		result, err = a.sonarr.GrabRelease(ctx, input.GUID, input.IndexerID)
 
-	case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie":
+	case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie",
+		"get_movie_detail", "get_movie_quality_profiles", "get_movie_root_folders", "get_movie_download_clients",
+		"get_movie_blocklist", "manual_movie_search", "update_movie_monitoring", "delete_movie",
+		"trigger_movie_search", "grab_movie_release", "remove_movie_blocklist_item":
 		if a.radarr == nil {
 			return jsonError("Radarr integration is not configured"), true
 		}
@@ -494,6 +497,85 @@ func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.Raw
 				return jsonError("invalid input: " + err.Error()), true
 			}
 			err = a.radarr.RemoveFailed(ctx, input.ID, input.Blocklist)
+			if err == nil {
+				result = map[string]string{"status": "removed"}
+			}
+		case "get_movie_detail":
+			var input getMovieDetailInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			result, err = a.radarr.GetMovie(ctx, input.MovieID)
+		case "get_movie_quality_profiles":
+			result, err = a.radarr.GetQualityProfiles(ctx)
+		case "get_movie_root_folders":
+			result, err = a.radarr.GetRootFolders(ctx)
+		case "get_movie_download_clients":
+			result, err = a.radarr.GetDownloadClients(ctx)
+		case "get_movie_blocklist":
+			var input getMovieBlocklistInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			pageSize := input.PageSize
+			if pageSize == 0 {
+				pageSize = 20
+			}
+			result, err = a.radarr.GetBlocklist(ctx, pageSize)
+		case "manual_movie_search":
+			var input manualMovieSearchInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			result, err = a.radarr.ManualSearch(ctx, input.MovieID)
+		case "update_movie_monitoring":
+			var input updateMovieMonitoringInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			movie, getErr := a.radarr.GetMovie(ctx, input.MovieID)
+			if getErr != nil {
+				err = getErr
+			} else {
+				movie.Monitored = input.Monitored
+				result, err = a.radarr.UpdateMovie(ctx, movie)
+			}
+		case "delete_movie":
+			var input deleteMovieInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			err = a.radarr.DeleteMovie(ctx, input.MovieID, input.DeleteFiles)
+			if err == nil {
+				result = map[string]string{"status": "deleted"}
+			}
+		case "trigger_movie_search":
+			var input triggerMovieSearchInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			err = a.radarr.Command(ctx, radarr.CommandRequest{
+				Name:     "MoviesSearch",
+				MovieIDs: []int{input.MovieID},
+			})
+			if err == nil {
+				result = map[string]string{"status": "search triggered"}
+			}
+		case "grab_movie_release":
+			var input grabMovieReleaseInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			err = a.radarr.GrabRelease(ctx, input.GUID, input.IndexerID)
+			if err == nil {
+				result = map[string]string{"status": "grabbed"}
+			}
+		case "remove_movie_blocklist_item":
+			var input removeMovieBlocklistItemInput
+			if err := json.Unmarshal(rawInput, &input); err != nil {
+				return jsonError("invalid input: " + err.Error()), true
+			}
+			err = a.radarr.DeleteBlocklistItem(ctx, input.ID)
 			if err == nil {
 				result = map[string]string{"status": "removed"}
 			}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -114,6 +114,39 @@ func (m *mockRadarr) Health(_ context.Context) ([]radarr.HealthCheck, error) {
 func (m *mockRadarr) RemoveFailed(_ context.Context, _ int, _ bool) error {
 	return nil
 }
+func (m *mockRadarr) GetMovie(_ context.Context, id int) (*radarr.Movie, error) {
+	return &radarr.Movie{ID: id, Title: "Test Movie"}, nil
+}
+func (m *mockRadarr) GetQualityProfiles(_ context.Context) ([]radarr.QualityProfile, error) {
+	return []radarr.QualityProfile{{ID: 1, Name: "HD"}}, nil
+}
+func (m *mockRadarr) GetRootFolders(_ context.Context) ([]radarr.RootFolder, error) {
+	return []radarr.RootFolder{{Path: "/movies"}}, nil
+}
+func (m *mockRadarr) GetDownloadClients(_ context.Context) ([]radarr.DownloadClient, error) {
+	return []radarr.DownloadClient{{Name: "qBit", Enable: true}}, nil
+}
+func (m *mockRadarr) GetBlocklist(_ context.Context, _ int) (*radarr.BlocklistPage, error) {
+	return &radarr.BlocklistPage{}, nil
+}
+func (m *mockRadarr) ManualSearch(_ context.Context, _ int) ([]radarr.Release, error) {
+	return []radarr.Release{}, nil
+}
+func (m *mockRadarr) UpdateMovie(_ context.Context, movie *radarr.Movie) (*radarr.Movie, error) {
+	return movie, nil
+}
+func (m *mockRadarr) DeleteMovie(_ context.Context, _ int, _ bool) error {
+	return nil
+}
+func (m *mockRadarr) Command(_ context.Context, _ radarr.CommandRequest) error {
+	return nil
+}
+func (m *mockRadarr) GrabRelease(_ context.Context, _ string, _ int) error {
+	return nil
+}
+func (m *mockRadarr) DeleteBlocklistItem(_ context.Context, _ int) error {
+	return nil
+}
 
 // mockProwlarr implements prowlarr.Client for agent testing.
 type mockProwlarr struct {

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -92,6 +92,41 @@ type getMovieHistoryInput struct {
 	PageSize int `json:"page_size,omitempty" jsonschema_description:"Number of history records to return (default 20)"`
 }
 
+type getMovieDetailInput struct {
+	MovieID int `json:"movie_id" jsonschema_description:"Radarr movie ID"`
+}
+
+type getMovieBlocklistInput struct {
+	PageSize int `json:"page_size,omitempty" jsonschema_description:"Number of blocklist records to return (default 20)"`
+}
+
+type manualMovieSearchInput struct {
+	MovieID int `json:"movie_id" jsonschema_description:"Movie ID to search releases for"`
+}
+
+type updateMovieMonitoringInput struct {
+	MovieID   int  `json:"movie_id" jsonschema_description:"Radarr movie ID"`
+	Monitored bool `json:"monitored" jsonschema_description:"Whether the movie should be monitored"`
+}
+
+type deleteMovieInput struct {
+	MovieID     int  `json:"movie_id" jsonschema_description:"Radarr movie ID to delete"`
+	DeleteFiles bool `json:"delete_files,omitempty" jsonschema_description:"Whether to delete movie files from disk (default false)"`
+}
+
+type triggerMovieSearchInput struct {
+	MovieID int `json:"movie_id" jsonschema_description:"Movie ID to trigger a search for"`
+}
+
+type grabMovieReleaseInput struct {
+	GUID      string `json:"guid" jsonschema_description:"Release GUID from manual search results"`
+	IndexerID int    `json:"indexer_id" jsonschema_description:"Indexer ID from manual search results"`
+}
+
+type removeMovieBlocklistItemInput struct {
+	ID int `json:"id" jsonschema_description:"Blocklist item ID to remove"`
+}
+
 type testIndexerInput struct {
 	ID int `json:"id" jsonschema_description:"Indexer ID to test connectivity for"`
 }
@@ -184,24 +219,29 @@ type toolDef struct {
 
 // destructiveTools is the set of tools that modify state.
 var destructiveTools = map[string]bool{
-	"add_series":              true,
-	"remove_failed":           true,
-	"update_series_monitoring": true,
-	"trigger_series_search":   true,
-	"delete_series":           true,
-	"remove_blocklist_item":   true,
-	"grab_release":            true,
-	"add_movie":               true,
-	"remove_failed_movie":     true,
-	"approve_request":         true,
-	"decline_request":         true,
-	"delete_request":          true,
-	"retry_request":           true,
-	"notebook_write":          true,
-	"notebook_delete":         true,
-	"enable_indexer":           true,
-	"update_indexer_priority":  true,
-	"delete_indexer":           true,
+	"add_series":                  true,
+	"remove_failed":               true,
+	"update_series_monitoring":    true,
+	"trigger_series_search":       true,
+	"delete_series":               true,
+	"remove_blocklist_item":       true,
+	"grab_release":                true,
+	"add_movie":                   true,
+	"remove_failed_movie":         true,
+	"update_movie_monitoring":     true,
+	"delete_movie":                true,
+	"trigger_movie_search":        true,
+	"grab_movie_release":          true,
+	"remove_movie_blocklist_item": true,
+	"approve_request":             true,
+	"decline_request":             true,
+	"delete_request":              true,
+	"retry_request":               true,
+	"notebook_write":              true,
+	"notebook_delete":             true,
+	"enable_indexer":              true,
+	"update_indexer_priority":     true,
+	"delete_indexer":              true,
 }
 
 // IsDestructive reports whether the named tool modifies state.
@@ -406,6 +446,88 @@ func radarrToolDefs() []toolDef {
 				Name:        "remove_failed_movie",
 				Description: anthropic.String("Remove a failed download from the Radarr queue. Optionally blocklist the release to prevent re-downloading."),
 				InputSchema: generateSchema[removeFailedMovieInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "get_movie_detail",
+				Description: anthropic.String("Get detailed information about a specific movie including file status, quality profile, and root folder path."),
+				InputSchema: generateSchema[getMovieDetailInput](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "get_movie_quality_profiles",
+				Description: anthropic.String("List all quality profiles configured in Radarr with their cutoff settings."),
+				InputSchema: generateSchema[struct{}](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "get_movie_root_folders",
+				Description: anthropic.String("List Radarr root folders with free and total disk space."),
+				InputSchema: generateSchema[struct{}](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "get_movie_download_clients",
+				Description: anthropic.String("List download clients configured in Radarr with their status, protocol, and priority."),
+				InputSchema: generateSchema[struct{}](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "get_movie_blocklist",
+				Description: anthropic.String("Get blocklisted releases that Radarr will not re-download."),
+				InputSchema: generateSchema[getMovieBlocklistInput](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "manual_movie_search",
+				Description: anthropic.String("Search for available releases for a specific movie. Shows indexer, quality, size, and rejection reasons."),
+				InputSchema: generateSchema[manualMovieSearchInput](),
+			},
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "update_movie_monitoring",
+				Description: anthropic.String("Update the monitoring status of a movie in Radarr. Fetches the movie, sets the monitored flag, and saves it back."),
+				InputSchema: generateSchema[updateMovieMonitoringInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "delete_movie",
+				Description: anthropic.String("Delete a movie from Radarr. Optionally delete files from disk."),
+				InputSchema: generateSchema[deleteMovieInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "trigger_movie_search",
+				Description: anthropic.String("Trigger an automatic search for a movie in Radarr. Sends a MoviesSearch command."),
+				InputSchema: generateSchema[triggerMovieSearchInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "grab_movie_release",
+				Description: anthropic.String("Grab a specific release for a movie from manual search results."),
+				InputSchema: generateSchema[grabMovieReleaseInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "remove_movie_blocklist_item",
+				Description: anthropic.String("Remove an item from the Radarr blocklist, allowing it to be downloaded again."),
+				InputSchema: generateSchema[removeMovieBlocklistItemInput](),
 			},
 			Destructive: true,
 		},

--- a/internal/radarr/client.go
+++ b/internal/radarr/client.go
@@ -19,6 +19,17 @@ type Client interface {
 	History(ctx context.Context, pageSize int) (*HistoryPage, error)
 	Health(ctx context.Context) ([]HealthCheck, error)
 	RemoveFailed(ctx context.Context, id int, blocklist bool) error
+	GetMovie(ctx context.Context, movieID int) (*Movie, error)
+	GetQualityProfiles(ctx context.Context) ([]QualityProfile, error)
+	GetRootFolders(ctx context.Context) ([]RootFolder, error)
+	GetDownloadClients(ctx context.Context) ([]DownloadClient, error)
+	GetBlocklist(ctx context.Context, pageSize int) (*BlocklistPage, error)
+	ManualSearch(ctx context.Context, movieID int) ([]Release, error)
+	UpdateMovie(ctx context.Context, movie *Movie) (*Movie, error)
+	DeleteMovie(ctx context.Context, movieID int, deleteFiles bool) error
+	Command(ctx context.Context, cmd CommandRequest) error
+	GrabRelease(ctx context.Context, guid string, indexerID int) error
+	DeleteBlocklistItem(ctx context.Context, id int) error
 }
 
 // HTTPClient implements Client using Radarr's v3 REST API.
@@ -99,6 +110,141 @@ func (c *HTTPClient) Health(ctx context.Context) ([]HealthCheck, error) {
 	return result, nil
 }
 
+func (c *HTTPClient) GetMovie(ctx context.Context, movieID int) (*Movie, error) {
+	u := c.url(fmt.Sprintf("/api/v3/movie/%d", movieID))
+
+	var result Movie
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("get movie: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *HTTPClient) GetQualityProfiles(ctx context.Context) ([]QualityProfile, error) {
+	u := c.url("/api/v3/qualityprofile")
+
+	var result []QualityProfile
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("get quality profiles: %w", err)
+	}
+	return result, nil
+}
+
+func (c *HTTPClient) GetRootFolders(ctx context.Context) ([]RootFolder, error) {
+	u := c.url("/api/v3/rootfolder")
+
+	var result []RootFolder
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("get root folders: %w", err)
+	}
+	return result, nil
+}
+
+func (c *HTTPClient) GetDownloadClients(ctx context.Context) ([]DownloadClient, error) {
+	u := c.url("/api/v3/downloadclient")
+
+	var result []DownloadClient
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("get download clients: %w", err)
+	}
+	return result, nil
+}
+
+func (c *HTTPClient) GetBlocklist(ctx context.Context, pageSize int) (*BlocklistPage, error) {
+	u := c.url("/api/v3/blocklist")
+	if pageSize > 0 {
+		q := u.Query()
+		q.Set("pageSize", strconv.Itoa(pageSize))
+		u.RawQuery = q.Encode()
+	}
+
+	var result BlocklistPage
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("get blocklist: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *HTTPClient) ManualSearch(ctx context.Context, movieID int) ([]Release, error) {
+	u := c.url("/api/v3/release")
+	q := u.Query()
+	q.Set("movieId", strconv.Itoa(movieID))
+	u.RawQuery = q.Encode()
+
+	var result []Release
+	if err := c.get(ctx, u.String(), &result); err != nil {
+		return nil, fmt.Errorf("manual search: %w", err)
+	}
+	return result, nil
+}
+
+func (c *HTTPClient) UpdateMovie(ctx context.Context, movie *Movie) (*Movie, error) {
+	u := c.url(fmt.Sprintf("/api/v3/movie/%d", movie.ID))
+
+	body, err := json.Marshal(movie)
+	if err != nil {
+		return nil, fmt.Errorf("marshal movie: %w", err)
+	}
+
+	var result Movie
+	if err := c.put(ctx, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("update movie: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *HTTPClient) DeleteMovie(ctx context.Context, movieID int, deleteFiles bool) error {
+	u := c.url(fmt.Sprintf("/api/v3/movie/%d", movieID))
+	q := u.Query()
+	q.Set("deleteFiles", strconv.FormatBool(deleteFiles))
+	u.RawQuery = q.Encode()
+
+	if err := c.delete(ctx, u.String()); err != nil {
+		return fmt.Errorf("delete movie: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) Command(ctx context.Context, cmd CommandRequest) error {
+	u := c.url("/api/v3/command")
+
+	body, err := json.Marshal(cmd)
+	if err != nil {
+		return fmt.Errorf("marshal command: %w", err)
+	}
+
+	if err := c.post(ctx, u.String(), body, nil); err != nil {
+		return fmt.Errorf("command: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) GrabRelease(ctx context.Context, guid string, indexerID int) error {
+	u := c.url("/api/v3/release")
+
+	body, err := json.Marshal(GrabReleaseRequest{
+		GUID:      guid,
+		IndexerID: indexerID,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal grab release: %w", err)
+	}
+
+	if err := c.post(ctx, u.String(), body, nil); err != nil {
+		return fmt.Errorf("grab release: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) DeleteBlocklistItem(ctx context.Context, id int) error {
+	u := c.url(fmt.Sprintf("/api/v3/blocklist/%d", id))
+
+	if err := c.delete(ctx, u.String()); err != nil {
+		return fmt.Errorf("delete blocklist item: %w", err)
+	}
+	return nil
+}
+
 func (c *HTTPClient) RemoveFailed(ctx context.Context, id int, blocklist bool) error {
 	u := c.url(fmt.Sprintf("/api/v3/queue/%d", id))
 	q := u.Query()
@@ -130,6 +276,15 @@ func (c *HTTPClient) get(ctx context.Context, rawURL string, out any) error {
 
 func (c *HTTPClient) post(ctx context.Context, rawURL string, body []byte, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.do(req, out)
+}
+
+func (c *HTTPClient) put(ctx context.Context, rawURL string, body []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, rawURL, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/internal/radarr/client_test.go
+++ b/internal/radarr/client_test.go
@@ -181,3 +181,261 @@ func TestHistory(t *testing.T) {
 		t.Errorf("TotalRecords = %d, want 1", history.TotalRecords)
 	}
 }
+
+func TestGetMovie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/movie/42" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(Movie{ID: 42, Title: "Inception", Year: 2010})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	movie, err := client.GetMovie(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetMovie() error: %v", err)
+	}
+	if movie.Title != "Inception" {
+		t.Errorf("Title = %q, want %q", movie.Title, "Inception")
+	}
+}
+
+func TestGetQualityProfiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/qualityprofile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]QualityProfile{
+			{ID: 1, Name: "HD-1080p", Cutoff: 7},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	profiles, err := client.GetQualityProfiles(context.Background())
+	if err != nil {
+		t.Fatalf("GetQualityProfiles() error: %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].Name != "HD-1080p" {
+		t.Errorf("unexpected profiles: %+v", profiles)
+	}
+}
+
+func TestGetRootFolders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/rootfolder" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]RootFolder{
+			{Path: "/movies", FreeSpace: 1000000, TotalSpace: 5000000},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	folders, err := client.GetRootFolders(context.Background())
+	if err != nil {
+		t.Fatalf("GetRootFolders() error: %v", err)
+	}
+	if len(folders) != 1 || folders[0].Path != "/movies" {
+		t.Errorf("unexpected folders: %+v", folders)
+	}
+}
+
+func TestGetDownloadClients(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/downloadclient" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]DownloadClient{
+			{Name: "qBittorrent", Enable: true, Protocol: "torrent", Priority: 1},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	clients, err := client.GetDownloadClients(context.Background())
+	if err != nil {
+		t.Fatalf("GetDownloadClients() error: %v", err)
+	}
+	if len(clients) != 1 || clients[0].Name != "qBittorrent" {
+		t.Errorf("unexpected clients: %+v", clients)
+	}
+}
+
+func TestGetBlocklist(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/blocklist" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("pageSize") != "10" {
+			t.Errorf("pageSize = %s, want 10", r.URL.Query().Get("pageSize"))
+		}
+		json.NewEncoder(w).Encode(BlocklistPage{
+			TotalRecords: 1,
+			Records: []BlocklistItem{
+				{ID: 1, MovieID: 42, SourceTitle: "bad.release"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	bl, err := client.GetBlocklist(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetBlocklist() error: %v", err)
+	}
+	if bl.TotalRecords != 1 {
+		t.Errorf("TotalRecords = %d, want 1", bl.TotalRecords)
+	}
+}
+
+func TestManualSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/release" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("movieId") != "42" {
+			t.Errorf("movieId = %s, want 42", r.URL.Query().Get("movieId"))
+		}
+		json.NewEncoder(w).Encode([]Release{
+			{GUID: "abc123", Title: "Inception.2010.1080p", Indexer: "NZBgeek", Size: 5000000000},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	releases, err := client.ManualSearch(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ManualSearch() error: %v", err)
+	}
+	if len(releases) != 1 || releases[0].GUID != "abc123" {
+		t.Errorf("unexpected releases: %+v", releases)
+	}
+}
+
+func TestUpdateMovie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/movie/42" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var movie Movie
+		json.NewDecoder(r.Body).Decode(&movie)
+		if !movie.Monitored {
+			t.Errorf("expected Monitored=true")
+		}
+		json.NewEncoder(w).Encode(movie)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	movie := &Movie{ID: 42, Title: "Inception", Monitored: true}
+	updated, err := client.UpdateMovie(context.Background(), movie)
+	if err != nil {
+		t.Fatalf("UpdateMovie() error: %v", err)
+	}
+	if !updated.Monitored {
+		t.Errorf("expected Monitored=true after update")
+	}
+}
+
+func TestDeleteMovie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/movie/42" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("deleteFiles") != "true" {
+			t.Errorf("deleteFiles = %s, want true", r.URL.Query().Get("deleteFiles"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.DeleteMovie(context.Background(), 42, true)
+	if err != nil {
+		t.Fatalf("DeleteMovie() error: %v", err)
+	}
+}
+
+func TestCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/command" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var cmd CommandRequest
+		json.NewDecoder(r.Body).Decode(&cmd)
+		if cmd.Name != "MoviesSearch" {
+			t.Errorf("Name = %q, want MoviesSearch", cmd.Name)
+		}
+		if len(cmd.MovieIDs) != 1 || cmd.MovieIDs[0] != 42 {
+			t.Errorf("MovieIDs = %v, want [42]", cmd.MovieIDs)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.Command(context.Background(), CommandRequest{Name: "MoviesSearch", MovieIDs: []int{42}})
+	if err != nil {
+		t.Fatalf("Command() error: %v", err)
+	}
+}
+
+func TestGrabRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/release" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var req GrabReleaseRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.GUID != "abc123" {
+			t.Errorf("GUID = %q, want abc123", req.GUID)
+		}
+		if req.IndexerID != 5 {
+			t.Errorf("IndexerID = %d, want 5", req.IndexerID)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.GrabRelease(context.Background(), "abc123", 5)
+	if err != nil {
+		t.Fatalf("GrabRelease() error: %v", err)
+	}
+}
+
+func TestDeleteBlocklistItem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/blocklist/99" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key")
+	err := client.DeleteBlocklistItem(context.Background(), 99)
+	if err != nil {
+		t.Fatalf("DeleteBlocklistItem() error: %v", err)
+	}
+}

--- a/internal/radarr/client_test.go
+++ b/internal/radarr/client_test.go
@@ -375,8 +375,8 @@ func TestCommand(t *testing.T) {
 		}
 		var cmd CommandRequest
 		json.NewDecoder(r.Body).Decode(&cmd)
-		if cmd.Name != "MoviesSearch" {
-			t.Errorf("Name = %q, want MoviesSearch", cmd.Name)
+		if cmd.Name != CommandMoviesSearch {
+			t.Errorf("Name = %q, want %s", cmd.Name, CommandMoviesSearch)
 		}
 		if len(cmd.MovieIDs) != 1 || cmd.MovieIDs[0] != 42 {
 			t.Errorf("MovieIDs = %v, want [42]", cmd.MovieIDs)
@@ -387,7 +387,7 @@ func TestCommand(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(srv.URL, "test-key")
-	err := client.Command(context.Background(), CommandRequest{Name: "MoviesSearch", MovieIDs: []int{42}})
+	err := client.Command(context.Background(), CommandRequest{Name: CommandMoviesSearch, MovieIDs: []int{42}})
 	if err != nil {
 		t.Fatalf("Command() error: %v", err)
 	}

--- a/internal/radarr/types.go
+++ b/internal/radarr/types.go
@@ -60,3 +60,56 @@ type HealthCheck struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
 }
+
+type QualityProfile struct {
+	ID     int    `json:"id"`
+	Name   string `json:"name"`
+	Cutoff int    `json:"cutoff"`
+}
+
+type RootFolder struct {
+	Path       string `json:"path"`
+	FreeSpace  int64  `json:"freeSpace"`
+	TotalSpace int64  `json:"totalSpace"`
+}
+
+type DownloadClient struct {
+	Name     string `json:"name"`
+	Enable   bool   `json:"enable"`
+	Protocol string `json:"protocol"`
+	Priority int    `json:"priority"`
+}
+
+type Release struct {
+	GUID       string   `json:"guid"`
+	Title      string   `json:"title"`
+	Indexer    string   `json:"indexer"`
+	IndexerID  int      `json:"indexerId"`
+	Quality    string   `json:"quality"`
+	Size       int64    `json:"size"`
+	Age        int      `json:"age"`
+	Rejected   bool     `json:"rejected"`
+	Rejections []string `json:"rejections,omitempty"`
+}
+
+type BlocklistItem struct {
+	ID          int    `json:"id"`
+	MovieID     int    `json:"movieId"`
+	SourceTitle string `json:"sourceTitle"`
+	Date        string `json:"date"`
+}
+
+type BlocklistPage struct {
+	TotalRecords int             `json:"totalRecords"`
+	Records      []BlocklistItem `json:"records"`
+}
+
+type CommandRequest struct {
+	Name     string `json:"name"`
+	MovieIDs []int  `json:"movieIds,omitempty"`
+}
+
+type GrabReleaseRequest struct {
+	GUID      string `json:"guid"`
+	IndexerID int    `json:"indexerId"`
+}

--- a/internal/radarr/types.go
+++ b/internal/radarr/types.go
@@ -104,6 +104,10 @@ type BlocklistPage struct {
 	Records      []BlocklistItem `json:"records"`
 }
 
+const (
+	CommandMoviesSearch = "MoviesSearch"
+)
+
 type CommandRequest struct {
 	Name     string `json:"name"`
 	MovieIDs []int  `json:"movieIds,omitempty"`


### PR DESCRIPTION
## Summary
- Add PUT HTTP method support to Radarr client
- Add 6 missing read endpoints: GetMovie, GetQualityProfiles, GetRootFolders, GetDownloadClients, GetBlocklist, ManualSearch
- Add 5 write endpoints: UpdateMovie, DeleteMovie, Command, GrabRelease, DeleteBlocklistItem
- Add 11 new agent tools with corresponding dispatch cases (write tools marked destructive)
- Add httptest-based tests for all new client methods and mock stubs for agent tests

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all tests pass including 11 new radarr client tests
- [ ] Manual verification against a live Radarr instance

Run: 20260403-1805-9241