### PR TITLE
feat: persist conversation history to disk across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ services.reel-life = {
   chatTelegramAllowedUsers = [ 123456789 ];
   notebookEnabled = true;
   notebookPath = "/var/lib/reel-life/notebook.json";
+  agentHistoryPath = "/var/lib/reel-life/history.json";
   environmentFiles = [
     config.age.secrets.anthropic-key.path
     config.age.secrets.sonarr-api-key.path
@@ -103,6 +104,7 @@ agent:
   model: claude-sonnet-4-5-20250929
   max_tokens: 4096
   history_size: 40  # conversation turns per chat (0 = disabled)
+  history_path: /var/lib/reel-life/history.json  # persist between restarts
 
 notebook:
   enabled: true

--- a/cmd/reel-life/main.go
+++ b/cmd/reel-life/main.go
@@ -74,8 +74,13 @@ func main() {
 	// Build conversation history store.
 	var historyStore *agent.HistoryStore
 	if cfg.Agent.HistorySize > 0 {
-		historyStore = agent.NewHistoryStore(cfg.Agent.HistorySize)
-		logger.Info("conversation history enabled", "max_turns", cfg.Agent.HistorySize)
+		if cfg.Agent.HistoryPath != "" {
+			historyStore = agent.NewPersistentHistoryStore(cfg.Agent.HistorySize, cfg.Agent.HistoryPath)
+			logger.Info("persistent conversation history enabled", "max_turns", cfg.Agent.HistorySize, "path", cfg.Agent.HistoryPath)
+		} else {
+			historyStore = agent.NewHistoryStore(cfg.Agent.HistorySize)
+			logger.Info("conversation history enabled", "max_turns", cfg.Agent.HistorySize)
+		}
 	}
 
 	// Select notifier based on backend configuration.

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -10,11 +10,12 @@ type Turn struct {
 
 // ConversationBuffer is a thread-safe ring buffer for conversation turns.
 type ConversationBuffer struct {
-	mu    sync.Mutex
-	turns []Turn
-	head  int
-	count int
-	cap   int
+	mu       sync.Mutex
+	turns    []Turn
+	head     int
+	count    int
+	cap      int
+	onChange func()
 }
 
 // NewConversationBuffer creates a buffer that holds up to capacity turns.
@@ -28,8 +29,6 @@ func NewConversationBuffer(capacity int) *ConversationBuffer {
 // Add appends a turn, overwriting the oldest when full.
 func (b *ConversationBuffer) Add(role, content string) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	idx := (b.head + b.count) % b.cap
 	if b.count == b.cap {
 		// Buffer full — overwrite oldest and advance head.
@@ -38,6 +37,12 @@ func (b *ConversationBuffer) Add(role, content string) {
 	} else {
 		b.turns[idx] = Turn{Role: role, Content: content}
 		b.count++
+	}
+	cb := b.onChange
+	b.mu.Unlock()
+
+	if cb != nil {
+		cb()
 	}
 }
 

--- a/internal/agent/history_store.go
+++ b/internal/agent/history_store.go
@@ -1,20 +1,40 @@
 package agent
 
-import "sync"
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+)
 
 // HistoryStore maps chat IDs to per-chat conversation buffers.
 type HistoryStore struct {
 	mu      sync.RWMutex
 	buffers map[string]*ConversationBuffer
 	cap     int
+	path    string // empty = in-memory only
 }
 
-// NewHistoryStore creates a store where each chat gets a buffer of turnCapacity turns.
+// NewHistoryStore creates an in-memory store where each chat gets a buffer of turnCapacity turns.
 func NewHistoryStore(turnCapacity int) *HistoryStore {
 	return &HistoryStore{
 		buffers: make(map[string]*ConversationBuffer),
 		cap:     turnCapacity,
 	}
+}
+
+// NewPersistentHistoryStore creates a store that persists conversation history to a JSON file.
+// Existing history is loaded from the file on creation. If the file doesn't exist or is
+// corrupt, the store starts empty.
+func NewPersistentHistoryStore(turnCapacity int, path string) *HistoryStore {
+	s := &HistoryStore{
+		buffers: make(map[string]*ConversationBuffer),
+		cap:     turnCapacity,
+		path:    path,
+	}
+	s.load()
+	return s
 }
 
 // Get returns the conversation buffer for the given chat ID, creating one if needed.
@@ -35,6 +55,97 @@ func (s *HistoryStore) Get(chatID string) *ConversationBuffer {
 	}
 
 	buf = NewConversationBuffer(s.cap)
+	if s.path != "" {
+		buf.onChange = func() { s.save() }
+	}
 	s.buffers[chatID] = buf
+	s.saveLocked()
 	return buf
+}
+
+// historyFile is the JSON structure persisted to disk.
+type historyFile struct {
+	Chats map[string][]Turn `json:"chats"`
+}
+
+// load reads persisted history from disk and populates buffers.
+// Must be called before the store is used concurrently (i.e., during construction).
+func (s *HistoryStore) load() {
+	if s.path == "" {
+		return
+	}
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("failed to read history file, starting empty", "path", s.path, "error", err)
+		}
+		return
+	}
+
+	var hf historyFile
+	if err := json.Unmarshal(data, &hf); err != nil {
+		slog.Warn("corrupt history file, starting empty", "path", s.path, "error", err)
+		return
+	}
+
+	for chatID, turns := range hf.Chats {
+		buf := NewConversationBuffer(s.cap)
+		for _, t := range turns {
+			buf.Add(t.Role, t.Content)
+		}
+		buf.onChange = func() { s.save() }
+		s.buffers[chatID] = buf
+	}
+}
+
+// save persists the full store state to disk. Acquires the store mutex.
+func (s *HistoryStore) save() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	s.saveLocked()
+}
+
+// saveLocked persists state to disk. Caller must hold at least a read lock on s.mu.
+func (s *HistoryStore) saveLocked() {
+	if s.path == "" {
+		return
+	}
+
+	hf := historyFile{Chats: make(map[string][]Turn, len(s.buffers))}
+	for chatID, buf := range s.buffers {
+		hf.Chats[chatID] = buf.Turns()
+	}
+
+	data, err := json.MarshalIndent(hf, "", "  ")
+	if err != nil {
+		slog.Error("failed to marshal history", "error", err)
+		return
+	}
+
+	// Atomic write: temp file + rename.
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".history-*.tmp")
+	if err != nil {
+		slog.Error("failed to create temp file for history", "error", err)
+		return
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		slog.Error("failed to write history temp file", "error", err)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		slog.Error("failed to close history temp file", "error", err)
+		return
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		os.Remove(tmpName)
+		slog.Error("failed to rename history file", "error", err)
+		return
+	}
 }

--- a/internal/agent/history_store.go
+++ b/internal/agent/history_store.go
@@ -13,7 +13,8 @@ type HistoryStore struct {
 	mu      sync.RWMutex
 	buffers map[string]*ConversationBuffer
 	cap     int
-	path    string // empty = in-memory only
+	path   string // empty = in-memory only
+	saveMu sync.Mutex
 }
 
 // NewHistoryStore creates an in-memory store where each chat gets a buffer of turnCapacity turns.
@@ -47,10 +48,10 @@ func (s *HistoryStore) Get(chatID string) *ConversationBuffer {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Double-check after acquiring write lock.
 	if buf, ok := s.buffers[chatID]; ok {
+		s.mu.Unlock()
 		return buf
 	}
 
@@ -59,7 +60,10 @@ func (s *HistoryStore) Get(chatID string) *ConversationBuffer {
 		buf.onChange = func() { s.save() }
 	}
 	s.buffers[chatID] = buf
-	s.saveLocked()
+	s.mu.Unlock()
+
+	// Save outside the write lock to avoid blocking concurrent readers during I/O.
+	s.save()
 	return buf
 }
 
@@ -99,23 +103,22 @@ func (s *HistoryStore) load() {
 	}
 }
 
-// save persists the full store state to disk. Acquires the store mutex.
+// save persists the full store state to disk.
+// Uses saveMu to serialize writes and releases the store read lock before I/O.
 func (s *HistoryStore) save() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	s.saveLocked()
-}
-
-// saveLocked persists state to disk. Caller must hold at least a read lock on s.mu.
-func (s *HistoryStore) saveLocked() {
 	if s.path == "" {
 		return
 	}
 
+	s.saveMu.Lock()
+	defer s.saveMu.Unlock()
+
+	s.mu.RLock()
 	hf := historyFile{Chats: make(map[string][]Turn, len(s.buffers))}
 	for chatID, buf := range s.buffers {
 		hf.Chats[chatID] = buf.Turns()
 	}
+	s.mu.RUnlock()
 
 	data, err := json.MarshalIndent(hf, "", "  ")
 	if err != nil {

--- a/internal/agent/history_test.go
+++ b/internal/agent/history_test.go
@@ -1,7 +1,10 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -143,5 +146,127 @@ func TestHistoryStoreConcurrentGet(t *testing.T) {
 		if buffers[i] != buffers[0] {
 			t.Fatalf("buffer[%d] differs from buffer[0]", i)
 		}
+	}
+}
+
+func TestPersistentHistoryStoreSaveAndLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+
+	// Create store, add data, let it persist.
+	store := NewPersistentHistoryStore(10, path)
+	store.Get("chat-1").Add("user", "hello")
+	store.Get("chat-1").Add("assistant", "hi there")
+	store.Get("chat-2").Add("user", "hey")
+
+	// Load into a new store and verify.
+	store2 := NewPersistentHistoryStore(10, path)
+	turns1 := store2.Get("chat-1").Turns()
+	if len(turns1) != 2 {
+		t.Fatalf("chat-1: got %d turns, want 2", len(turns1))
+	}
+	if turns1[0].Role != "user" || turns1[0].Content != "hello" {
+		t.Errorf("chat-1 turns[0] = %+v, want user/hello", turns1[0])
+	}
+	if turns1[1].Role != "assistant" || turns1[1].Content != "hi there" {
+		t.Errorf("chat-1 turns[1] = %+v, want assistant/hi there", turns1[1])
+	}
+
+	turns2 := store2.Get("chat-2").Turns()
+	if len(turns2) != 1 || turns2[0].Content != "hey" {
+		t.Errorf("chat-2 turns = %+v, want [user/hey]", turns2)
+	}
+}
+
+func TestPersistentHistoryStoreFileNotExist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	store := NewPersistentHistoryStore(10, path)
+	turns := store.Get("chat-1").Turns()
+	if len(turns) != 0 {
+		t.Errorf("expected empty turns for new store, got %d", len(turns))
+	}
+}
+
+func TestPersistentHistoryStoreCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+	os.WriteFile(path, []byte("not json{{{"), 0644)
+
+	store := NewPersistentHistoryStore(10, path)
+	turns := store.Get("chat-1").Turns()
+	if len(turns) != 0 {
+		t.Errorf("expected empty turns for corrupt file, got %d", len(turns))
+	}
+}
+
+func TestPersistentHistoryStoreAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "history.json")
+
+	store := NewPersistentHistoryStore(10, path)
+	store.Get("chat-1").Add("user", "hello")
+
+	// Verify the file exists and is valid JSON.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read history file: %v", err)
+	}
+	var hf struct {
+		Chats map[string][]Turn `json:"chats"`
+	}
+	if err := json.Unmarshal(data, &hf); err != nil {
+		t.Fatalf("history file is not valid JSON: %v", err)
+	}
+	if len(hf.Chats["chat-1"]) != 1 {
+		t.Errorf("expected 1 turn in file, got %d", len(hf.Chats["chat-1"]))
+	}
+
+	// No temp files should remain.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() != "history.json" {
+			t.Errorf("unexpected file in dir: %s", e.Name())
+		}
+	}
+}
+
+func TestPersistentHistoryStoreEvictionSurvivesReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+
+	store := NewPersistentHistoryStore(3, path)
+	buf := store.Get("chat-1")
+	buf.Add("user", "a")
+	buf.Add("assistant", "b")
+	buf.Add("user", "c")
+	buf.Add("assistant", "d") // evicts "a"
+
+	store2 := NewPersistentHistoryStore(3, path)
+	turns := store2.Get("chat-1").Turns()
+	if len(turns) != 3 {
+		t.Fatalf("got %d turns, want 3", len(turns))
+	}
+	if turns[0].Content != "b" {
+		t.Errorf("oldest turn = %q, want %q", turns[0].Content, "b")
+	}
+	if turns[2].Content != "d" {
+		t.Errorf("newest turn = %q, want %q", turns[2].Content, "d")
+	}
+}
+
+func TestPersistentHistoryStoreNewChatAfterReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+
+	store := NewPersistentHistoryStore(10, path)
+	store.Get("chat-1").Add("user", "hello")
+
+	// Reload and add a new chat.
+	store2 := NewPersistentHistoryStore(10, path)
+	store2.Get("chat-2").Add("user", "world")
+
+	// Reload again — both chats should be present.
+	store3 := NewPersistentHistoryStore(10, path)
+	if turns := store3.Get("chat-1").Turns(); len(turns) != 1 {
+		t.Errorf("chat-1: got %d turns, want 1", len(turns))
+	}
+	if turns := store3.Get("chat-2").Turns(); len(turns) != 1 {
+		t.Errorf("chat-2: got %d turns, want 1", len(turns))
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ type AgentConfig struct {
 	Model       string           `yaml:"model"`
 	MaxTokens   int              `yaml:"max_tokens"`
 	HistorySize int              `yaml:"history_size"`
+	HistoryPath string           `yaml:"history_path"`
 	RateLimits  *RateLimitConfig `yaml:"rate_limits,omitempty"`
 }
 
@@ -165,6 +166,9 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("NOTEBOOK_PATH"); v != "" {
 		cfg.Notebook.Path = v
+	}
+	if v := os.Getenv("HISTORY_PATH"); v != "" {
+		cfg.Agent.HistoryPath = v
 	}
 	if v := os.Getenv("REEL_LIFE_LATITUDE"); v != "" {
 		if lat, err := strconv.ParseFloat(v, 64); err == nil {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -93,6 +93,12 @@ in
       description = "Maximum conversation turns per chat (0 to disable history)";
     };
 
+    agentHistoryPath = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Path to persist conversation history (empty = in-memory only)";
+    };
+
     monitorEnabled = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -225,6 +231,8 @@ in
         model = cfg.agentModel;
         max_tokens = cfg.agentMaxTokens;
         history_size = cfg.agentHistorySize;
+      } // lib.optionalAttrs (cfg.agentHistoryPath != "") {
+        history_path = cfg.agentHistoryPath;
       };
       monitor = {
         enabled = cfg.monitorEnabled;
@@ -277,7 +285,9 @@ in
         ProtectHome = true;
         PrivateTmp = true;
         PrivateDevices = true;
-        ReadWritePaths = [ ];  # service is stateless
+        ReadWritePaths =
+          lib.optional (cfg.notebookPath != "") (builtins.dirOf cfg.notebookPath)
+          ++ lib.optional (cfg.agentHistoryPath != "") (builtins.dirOf cfg.agentHistoryPath);
 
         # Kernel: block access to tunables, modules, logs, cgroups, clock, hostname
         ProtectKernelTunables = true;


### PR DESCRIPTION
## Summary
- Add file-backed persistence to `HistoryStore` so conversation context survives service restarts
- New `NewPersistentHistoryStore` constructor loads existing history from a JSON file on startup and saves after every turn via an `onChange` callback on `ConversationBuffer`
- Uses atomic write-to-temp-then-rename pattern; gracefully handles missing or corrupt files
- Wired through config (`agent.history_path`), env var override (`HISTORY_PATH`), NixOS module option (`agentHistoryPath`), and systemd `ReadWritePaths`

## Test plan
- [x] All existing history tests pass unchanged (in-memory mode)
- [x] New tests: save/load round-trip, missing file, corrupt file, atomic write (no temp file leaks), eviction survives reload, new chat after reload
- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./...` — all packages pass

Run: 20260403-1807-79b8