### PR TITLE
feat: add episode-level monitoring tools to Sonarr

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -55,7 +55,7 @@ func (m *mockSonarr) RemoveFailed(_ context.Context, _ int, _ bool) error {
 func (m *mockSonarr) GetSeries(_ context.Context, _ int) (*sonarr.Series, error) {
 	return m.seriesResult, nil
 }
-func (m *mockSonarr) GetEpisodes(_ context.Context, _ int) ([]sonarr.Episode, error) {
+func (m *mockSonarr) GetEpisodes(_ context.Context, _ int, _ ...int) ([]sonarr.Episode, error) {
 	return m.episodesResult, nil
 }
 func (m *mockSonarr) GetLogs(_ context.Context, _ int, _ string) ([]sonarr.LogRecord, error) {
@@ -88,9 +88,6 @@ func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) (*sonarr.Re
 	return &sonarr.Release{}, nil
 }
 func (m *mockSonarr) MonitorEpisodes(_ context.Context, _ []int, _ bool) error { return nil }
-func (m *mockSonarr) UpdateEpisode(_ context.Context, ep *sonarr.Episode) (*sonarr.Episode, error) {
-	return ep, nil
-}
 
 // mockRadarr implements radarr.Client for agent testing.
 type mockRadarr struct {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -87,6 +87,10 @@ func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error  { retu
 func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) (*sonarr.Release, error) {
 	return &sonarr.Release{}, nil
 }
+func (m *mockSonarr) MonitorEpisodes(_ context.Context, _ []int, _ bool) error { return nil }
+func (m *mockSonarr) UpdateEpisode(_ context.Context, ep *sonarr.Episode) (*sonarr.Episode, error) {
+	return ep, nil
+}
 
 // mockRadarr implements radarr.Client for agent testing.
 type mockRadarr struct {

--- a/internal/agent/dispatch_sonarr.go
+++ b/internal/agent/dispatch_sonarr.go
@@ -14,7 +14,8 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		case "search_series", "add_series", "get_queue", "get_history", "check_health", "remove_failed",
 			"get_series_detail", "get_episodes", "get_logs", "manual_search", "get_quality_profiles",
 			"get_blocklist", "get_root_folders", "get_download_clients", "update_series_monitoring",
-			"trigger_series_search", "delete_series", "remove_blocklist_item", "grab_release":
+			"trigger_series_search", "delete_series", "remove_blocklist_item", "grab_release",
+			"update_episode_monitoring", "monitor_season_episodes":
 			return jsonError("Sonarr integration is not configured"), true, true
 		}
 	}
@@ -178,6 +179,39 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 			return jsonError("invalid input: " + err.Error()), true, true
 		}
 		result, err = a.sonarr.GrabRelease(ctx, input.GUID, input.IndexerID)
+
+	case "update_episode_monitoring":
+		var input updateEpisodeMonitoringInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true, true
+		}
+		err = a.sonarr.MonitorEpisodes(ctx, []int{input.EpisodeID}, input.Monitored)
+		if err == nil {
+			result = map[string]string{"status": "updated"}
+		}
+
+	case "monitor_season_episodes":
+		var input monitorSeasonEpisodesInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true, true
+		}
+		episodes, getErr := a.sonarr.GetEpisodes(ctx, input.SeriesID)
+		if getErr != nil {
+			return jsonError(getErr.Error()), true, true
+		}
+		var ids []int
+		for _, ep := range episodes {
+			if ep.SeasonNumber == input.SeasonNumber {
+				ids = append(ids, ep.ID)
+			}
+		}
+		if len(ids) == 0 {
+			return jsonError(fmt.Sprintf("no episodes found for season %d", input.SeasonNumber)), true, true
+		}
+		err = a.sonarr.MonitorEpisodes(ctx, ids, input.Monitored)
+		if err == nil {
+			result = map[string]any{"status": "updated", "episodeCount": len(ids)}
+		}
 
 	default:
 		return "", false, false

--- a/internal/agent/dispatch_sonarr.go
+++ b/internal/agent/dispatch_sonarr.go
@@ -195,15 +195,13 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		if err := json.Unmarshal(rawInput, &input); err != nil {
 			return jsonError("invalid input: " + err.Error()), true, true
 		}
-		episodes, getErr := a.sonarr.GetEpisodes(ctx, input.SeriesID)
+		episodes, getErr := a.sonarr.GetEpisodes(ctx, input.SeriesID, input.SeasonNumber)
 		if getErr != nil {
 			return jsonError(getErr.Error()), true, true
 		}
 		var ids []int
 		for _, ep := range episodes {
-			if ep.SeasonNumber == input.SeasonNumber {
-				ids = append(ids, ep.ID)
-			}
+			ids = append(ids, ep.ID)
 		}
 		if len(ids) == 0 {
 			return jsonError(fmt.Sprintf("no episodes found for season %d", input.SeasonNumber)), true, true

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -32,6 +32,8 @@ var destructiveTools = map[string]bool{
 	"delete_series":               true,
 	"remove_blocklist_item":       true,
 	"grab_release":                true,
+	"update_episode_monitoring":   true,
+	"monitor_season_episodes":     true,
 	"add_movie":                   true,
 	"remove_failed_movie":         true,
 	"update_movie_monitoring":     true,

--- a/internal/agent/tools_sonarr.go
+++ b/internal/agent/tools_sonarr.go
@@ -68,6 +68,17 @@ type grabReleaseInput struct {
 	IndexerID int    `json:"indexer_id" jsonschema_description:"Indexer ID from manual_search results"`
 }
 
+type updateEpisodeMonitoringInput struct {
+	EpisodeID int  `json:"episode_id" jsonschema_description:"Sonarr episode ID to update monitoring for"`
+	Monitored bool `json:"monitored" jsonschema_description:"Whether to enable (true) or disable (false) monitoring"`
+}
+
+type monitorSeasonEpisodesInput struct {
+	SeriesID     int  `json:"series_id" jsonschema_description:"Sonarr series ID"`
+	SeasonNumber int  `json:"season_number" jsonschema_description:"Season number whose episodes to update monitoring for"`
+	Monitored    bool `json:"monitored" jsonschema_description:"Whether to enable (true) or disable (false) monitoring for all episodes in the season"`
+}
+
 func sonarrToolDefs() []toolDef {
 	return []toolDef{
 		{
@@ -207,6 +218,22 @@ func sonarrToolDefs() []toolDef {
 				Name:        "grab_release",
 				Description: anthropic.String("Download a specific release found via manual_search. Requires the GUID and indexer ID from the search results."),
 				InputSchema: generateSchema[grabReleaseInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "update_episode_monitoring",
+				Description: anthropic.String("Enable or disable monitoring for a single episode. Use get_episodes first to find the episode ID."),
+				InputSchema: generateSchema[updateEpisodeMonitoringInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "monitor_season_episodes",
+				Description: anthropic.String("Enable or disable monitoring for all episodes in a specific season. Use get_series_detail first to find the series ID."),
+				InputSchema: generateSchema[monitorSeasonEpisodesInput](),
 			},
 			Destructive: true,
 		},

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -64,6 +64,10 @@ func (m *mockSonarr) DeleteBlocklistItem(_ context.Context, _ int) error  { retu
 func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) (*sonarr.Release, error) {
 	return &sonarr.Release{}, nil
 }
+func (m *mockSonarr) MonitorEpisodes(_ context.Context, _ []int, _ bool) error { return nil }
+func (m *mockSonarr) UpdateEpisode(_ context.Context, ep *sonarr.Episode) (*sonarr.Episode, error) {
+	return ep, nil
+}
 
 // mockNotifier records sent messages.
 type mockNotifier struct {

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -32,7 +32,7 @@ func (m *mockSonarr) RemoveFailed(_ context.Context, _ int, _ bool) error { retu
 func (m *mockSonarr) GetSeries(_ context.Context, _ int) (*sonarr.Series, error) {
 	return nil, nil
 }
-func (m *mockSonarr) GetEpisodes(_ context.Context, _ int) ([]sonarr.Episode, error) {
+func (m *mockSonarr) GetEpisodes(_ context.Context, _ int, _ ...int) ([]sonarr.Episode, error) {
 	return nil, nil
 }
 func (m *mockSonarr) GetLogs(_ context.Context, _ int, _ string) ([]sonarr.LogRecord, error) {
@@ -65,9 +65,6 @@ func (m *mockSonarr) GrabRelease(_ context.Context, _ string, _ int) (*sonarr.Re
 	return &sonarr.Release{}, nil
 }
 func (m *mockSonarr) MonitorEpisodes(_ context.Context, _ []int, _ bool) error { return nil }
-func (m *mockSonarr) UpdateEpisode(_ context.Context, ep *sonarr.Episode) (*sonarr.Episode, error) {
-	return ep, nil
-}
 
 // mockNotifier records sent messages.
 type mockNotifier struct {

--- a/internal/sonarr/client.go
+++ b/internal/sonarr/client.go
@@ -32,6 +32,8 @@ type Client interface {
 	DeleteSeries(ctx context.Context, seriesID int, deleteFiles bool) error
 	DeleteBlocklistItem(ctx context.Context, id int) error
 	GrabRelease(ctx context.Context, guid string, indexerID int) (*Release, error)
+	MonitorEpisodes(ctx context.Context, episodeIDs []int, monitored bool) error
+	UpdateEpisode(ctx context.Context, episode *Episode) (*Episode, error)
 }
 
 // HTTPClient implements Client using Sonarr's v3 REST API.
@@ -291,6 +293,35 @@ func (c *HTTPClient) GrabRelease(ctx context.Context, guid string, indexerID int
 	var result Release
 	if err := c.post(ctx, u.String(), body, &result); err != nil {
 		return nil, fmt.Errorf("grab release: %w", err)
+	}
+	return &result, nil
+}
+
+func (c *HTTPClient) MonitorEpisodes(ctx context.Context, episodeIDs []int, monitored bool) error {
+	u := c.url("/api/v3/episode/monitor")
+
+	body, err := json.Marshal(MonitorEpisodesRequest{EpisodeIDs: episodeIDs, Monitored: monitored})
+	if err != nil {
+		return fmt.Errorf("marshal monitor episodes request: %w", err)
+	}
+
+	if err := c.put(ctx, u.String(), body, nil); err != nil {
+		return fmt.Errorf("monitor episodes: %w", err)
+	}
+	return nil
+}
+
+func (c *HTTPClient) UpdateEpisode(ctx context.Context, episode *Episode) (*Episode, error) {
+	u := c.url(fmt.Sprintf("/api/v3/episode/%d", episode.ID))
+
+	body, err := json.Marshal(episode)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update episode: %w", err)
+	}
+
+	var result Episode
+	if err := c.put(ctx, u.String(), body, &result); err != nil {
+		return nil, fmt.Errorf("update episode: %w", err)
 	}
 	return &result, nil
 }

--- a/internal/sonarr/client.go
+++ b/internal/sonarr/client.go
@@ -20,7 +20,7 @@ type Client interface {
 	Health(ctx context.Context) ([]HealthCheck, error)
 	RemoveFailed(ctx context.Context, id int, blocklist bool) error
 	GetSeries(ctx context.Context, seriesID int) (*Series, error)
-	GetEpisodes(ctx context.Context, seriesID int) ([]Episode, error)
+	GetEpisodes(ctx context.Context, seriesID int, seasonNumber ...int) ([]Episode, error)
 	GetLogs(ctx context.Context, pageSize int, level string) ([]LogRecord, error)
 	ManualSearch(ctx context.Context, episodeID int) ([]Release, error)
 	GetQualityProfiles(ctx context.Context) ([]QualityProfile, error)
@@ -33,7 +33,6 @@ type Client interface {
 	DeleteBlocklistItem(ctx context.Context, id int) error
 	GrabRelease(ctx context.Context, guid string, indexerID int) (*Release, error)
 	MonitorEpisodes(ctx context.Context, episodeIDs []int, monitored bool) error
-	UpdateEpisode(ctx context.Context, episode *Episode) (*Episode, error)
 }
 
 // HTTPClient implements Client using Sonarr's v3 REST API.
@@ -138,10 +137,13 @@ func (c *HTTPClient) GetSeries(ctx context.Context, seriesID int) (*Series, erro
 	return &result, nil
 }
 
-func (c *HTTPClient) GetEpisodes(ctx context.Context, seriesID int) ([]Episode, error) {
+func (c *HTTPClient) GetEpisodes(ctx context.Context, seriesID int, seasonNumber ...int) ([]Episode, error) {
 	u := c.url("/api/v3/episode")
 	q := u.Query()
 	q.Set("seriesId", strconv.Itoa(seriesID))
+	if len(seasonNumber) > 0 {
+		q.Set("seasonNumber", strconv.Itoa(seasonNumber[0]))
+	}
 	u.RawQuery = q.Encode()
 
 	var result []Episode
@@ -309,21 +311,6 @@ func (c *HTTPClient) MonitorEpisodes(ctx context.Context, episodeIDs []int, moni
 		return fmt.Errorf("monitor episodes: %w", err)
 	}
 	return nil
-}
-
-func (c *HTTPClient) UpdateEpisode(ctx context.Context, episode *Episode) (*Episode, error) {
-	u := c.url(fmt.Sprintf("/api/v3/episode/%d", episode.ID))
-
-	body, err := json.Marshal(episode)
-	if err != nil {
-		return nil, fmt.Errorf("marshal update episode: %w", err)
-	}
-
-	var result Episode
-	if err := c.put(ctx, u.String(), body, &result); err != nil {
-		return nil, fmt.Errorf("update episode: %w", err)
-	}
-	return &result, nil
 }
 
 func (c *HTTPClient) url(path string) *url.URL {

--- a/internal/sonarr/types.go
+++ b/internal/sonarr/types.go
@@ -160,3 +160,8 @@ type GrabReleaseRequest struct {
 	GUID      string `json:"guid"`
 	IndexerID int    `json:"indexerId"`
 }
+
+type MonitorEpisodesRequest struct {
+	EpisodeIDs []int `json:"episodeIds"`
+	Monitored  bool  `json:"monitored"`
+}


### PR DESCRIPTION
## Summary
- Adds `update_episode_monitoring` tool to toggle monitoring for a single episode via `PUT /api/v3/episode/monitor`
- Adds `monitor_season_episodes` tool to bulk-toggle monitoring for all episodes in a season (fetches episodes, filters by season, calls bulk monitor endpoint)
- Both tools are marked destructive; client interface extended with `MonitorEpisodes` and `UpdateEpisode` methods

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (mock clients updated in agent and monitor test suites)
- [x] `go vet ./...` clean
- [ ] Manual verification: use `update_episode_monitoring` to toggle a single episode
- [ ] Manual verification: use `monitor_season_episodes` to bulk-toggle a full season

Run: 20260404-1859-88c6