### PR TITLE
feat: add quality profile update tools for Sonarr and Radarr

### DIFF
--- a/internal/agent/dispatch_radarr.go
+++ b/internal/agent/dispatch_radarr.go
@@ -13,7 +13,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 		case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie",
 			"get_movie_detail", "get_movie_quality_profiles", "get_movie_root_folders", "get_movie_download_clients",
 			"get_movie_blocklist", "manual_movie_search", "update_movie_monitoring", "delete_movie",
-			"trigger_movie_search", "grab_movie_release", "remove_movie_blocklist_item":
+			"trigger_movie_search", "grab_movie_release", "remove_movie_blocklist_item", "update_movie_profile":
 			return jsonError("Radarr integration is not configured"), true, true
 		}
 	}
@@ -147,6 +147,18 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 		if err == nil {
 			result = map[string]string{"status": "removed"}
 		}
+	case "update_movie_profile":
+		var input updateMovieProfileInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true, true
+		}
+		movie, getErr := a.radarr.GetMovie(ctx, input.MovieID)
+		if getErr != nil {
+			err = getErr
+			break
+		}
+		movie.QualityProfileID = input.QualityProfileID
+		result, err = a.radarr.UpdateMovie(ctx, movie)
 	default:
 		return "", false, false
 	}

--- a/internal/agent/dispatch_sonarr.go
+++ b/internal/agent/dispatch_sonarr.go
@@ -15,7 +15,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 			"get_series_detail", "get_episodes", "get_logs", "manual_search", "get_quality_profiles",
 			"get_blocklist", "get_root_folders", "get_download_clients", "update_series_monitoring",
 			"trigger_series_search", "delete_series", "remove_blocklist_item", "grab_release",
-			"update_episode_monitoring", "monitor_season_episodes":
+			"update_episode_monitoring", "monitor_season_episodes", "update_series_profile":
 			return jsonError("Sonarr integration is not configured"), true, true
 		}
 	}
@@ -210,6 +210,18 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		if err == nil {
 			result = map[string]any{"status": "updated", "episodeCount": len(ids)}
 		}
+
+	case "update_series_profile":
+		var input updateSeriesProfileInput
+		if err := json.Unmarshal(rawInput, &input); err != nil {
+			return jsonError("invalid input: " + err.Error()), true, true
+		}
+		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
+		if getErr != nil {
+			return jsonError(getErr.Error()), true, true
+		}
+		series.QualityProfileID = input.QualityProfileID
+		result, err = a.sonarr.UpdateSeries(ctx, series)
 
 	default:
 		return "", false, false

--- a/internal/agent/dispatch_sonarr.go
+++ b/internal/agent/dispatch_sonarr.go
@@ -123,7 +123,8 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		}
 		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
 		if getErr != nil {
-			return jsonError(getErr.Error()), true, true
+			err = getErr
+			break
 		}
 		found := false
 		for i, s := range series.Seasons {
@@ -197,7 +198,8 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		}
 		episodes, getErr := a.sonarr.GetEpisodes(ctx, input.SeriesID, input.SeasonNumber)
 		if getErr != nil {
-			return jsonError(getErr.Error()), true, true
+			err = getErr
+			break
 		}
 		var ids []int
 		for _, ep := range episodes {
@@ -218,7 +220,8 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		}
 		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
 		if getErr != nil {
-			return jsonError(getErr.Error()), true, true
+			err = getErr
+			break
 		}
 		series.QualityProfileID = input.QualityProfileID
 		result, err = a.sonarr.UpdateSeries(ctx, series)

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -41,6 +41,8 @@ var destructiveTools = map[string]bool{
 	"trigger_movie_search":        true,
 	"grab_movie_release":          true,
 	"remove_movie_blocklist_item": true,
+	"update_series_profile":       true,
+	"update_movie_profile":        true,
 	"approve_request":             true,
 	"decline_request":             true,
 	"delete_request":              true,

--- a/internal/agent/tools_radarr.go
+++ b/internal/agent/tools_radarr.go
@@ -54,6 +54,11 @@ type grabMovieReleaseInput struct {
 	IndexerID int    `json:"indexer_id" jsonschema_description:"Indexer ID from manual search results"`
 }
 
+type updateMovieProfileInput struct {
+	MovieID          int `json:"movie_id" jsonschema_description:"Radarr movie ID"`
+	QualityProfileID int `json:"quality_profile_id" jsonschema_description:"Quality profile ID to assign. Use get_movie_quality_profiles to find available IDs."`
+}
+
 type removeMovieBlocklistItemInput struct {
 	ID int `json:"id" jsonschema_description:"Blocklist item ID to remove"`
 }
@@ -183,6 +188,14 @@ func radarrToolDefs() []toolDef {
 				Name:        "remove_movie_blocklist_item",
 				Description: anthropic.String("Remove an item from the Radarr blocklist, allowing it to be downloaded again."),
 				InputSchema: generateSchema[removeMovieBlocklistItemInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "update_movie_profile",
+				Description: anthropic.String("Update the quality profile for a movie. Use get_movie_quality_profiles to find available profile IDs and get_movie_detail to see the current profile."),
+				InputSchema: generateSchema[updateMovieProfileInput](),
 			},
 			Destructive: true,
 		},

--- a/internal/agent/tools_sonarr.go
+++ b/internal/agent/tools_sonarr.go
@@ -73,6 +73,11 @@ type updateEpisodeMonitoringInput struct {
 	Monitored bool `json:"monitored" jsonschema_description:"Whether to enable (true) or disable (false) monitoring"`
 }
 
+type updateSeriesProfileInput struct {
+	SeriesID         int `json:"series_id" jsonschema_description:"Sonarr series ID"`
+	QualityProfileID int `json:"quality_profile_id" jsonschema_description:"Quality profile ID to assign. Use get_quality_profiles to find available IDs."`
+}
+
 type monitorSeasonEpisodesInput struct {
 	SeriesID     int  `json:"series_id" jsonschema_description:"Sonarr series ID"`
 	SeasonNumber int  `json:"season_number" jsonschema_description:"Season number whose episodes to update monitoring for"`
@@ -234,6 +239,14 @@ func sonarrToolDefs() []toolDef {
 				Name:        "monitor_season_episodes",
 				Description: anthropic.String("Enable or disable monitoring for all episodes in a specific season. Use get_series_detail first to find the series ID."),
 				InputSchema: generateSchema[monitorSeasonEpisodesInput](),
+			},
+			Destructive: true,
+		},
+		{
+			Param: anthropic.ToolParam{
+				Name:        "update_series_profile",
+				Description: anthropic.String("Update the quality profile for a series. Use get_quality_profiles to find available profile IDs and get_series_detail to see the current profile."),
+				InputSchema: generateSchema[updateSeriesProfileInput](),
 			},
 			Destructive: true,
 		},


### PR DESCRIPTION
## Summary
- Add `update_series_profile` tool (Sonarr) to change a series' quality profile by fetching the series, setting the new profile ID, and calling UpdateSeries.
- Add `update_movie_profile` tool (Radarr) with the same pattern using GetMovie/UpdateMovie.
- Both tools are marked as destructive for rate limiting.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual test: use `get_quality_profiles` then `update_series_profile` to change a series' profile
- [ ] Manual test: use `get_movie_quality_profiles` then `update_movie_profile` to change a movie's profile

Run: 20260404-1921-3b5a