### PR TITLE
feat: separate mutative and destructive tool rate limits

### DIFF
--- a/cmd/reel-life/main.go
+++ b/cmd/reel-life/main.go
@@ -133,7 +133,7 @@ func main() {
 	// Build rate limiter from config (or defaults).
 	var limiter *agent.RateLimiter
 	rl := cfg.Agent.RateLimits
-	maxPerMin, maxPerReq, maxDestructive := agent.DefaultMaxCallsPerMinute, agent.DefaultMaxCallsPerRequest, agent.DefaultMaxDestructive
+	maxPerMin, maxPerReq, maxMutative, maxDestructive := agent.DefaultMaxCallsPerMinute, agent.DefaultMaxCallsPerRequest, agent.DefaultMaxMutative, agent.DefaultMaxDestructive
 	if rl != nil {
 		if rl.MaxCallsPerMinute > 0 {
 			maxPerMin = rl.MaxCallsPerMinute
@@ -141,11 +141,14 @@ func main() {
 		if rl.MaxCallsPerRequest > 0 {
 			maxPerReq = rl.MaxCallsPerRequest
 		}
+		if rl.MaxMutative > 0 {
+			maxMutative = rl.MaxMutative
+		}
 		if rl.MaxDestructive > 0 {
 			maxDestructive = rl.MaxDestructive
 		}
 	}
-	limiter = agent.NewRateLimiter(maxPerMin, maxPerReq, maxDestructive)
+	limiter = agent.NewRateLimiter(maxPerMin, maxPerReq, maxMutative, maxDestructive)
 
 	// Notebook (optional — enabled explicitly or when a path is set).
 	var nb notebook.Notebook

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -237,7 +237,7 @@ func (a *Agent) executeToolWithAudit(ctx context.Context, name string, rawInput 
 
 	// Rate limit check
 	if a.limiter != nil {
-		if err := a.limiter.Allow(name, IsDestructive(name)); err != nil {
+		if err := a.limiter.Allow(name, IsMutative(name), IsDestructive(name)); err != nil {
 			a.logger.Warn("tool rate limited",
 				"tool", name,
 				"error", err,

--- a/internal/agent/ratelimit.go
+++ b/internal/agent/ratelimit.go
@@ -9,28 +9,33 @@ import (
 const (
 	DefaultMaxCallsPerMinute  = 30
 	DefaultMaxCallsPerRequest = 10
+	DefaultMaxMutative        = 20
 	DefaultMaxDestructive     = 5
 )
 
 // RateLimiter enforces per-minute and per-request limits on tool calls,
-// with a separate limit for destructive (state-modifying) tools.
+// with separate limits for mutative (state-changing) and destructive
+// (data-removing) tools.
 type RateLimiter struct {
 	maxCallsPerMinute  int
 	maxCallsPerRequest int
+	mutativeLimit      int
 	destructiveLimit   int
 
 	minuteCount      int
 	requestCount     int
+	mutativeCount    int
 	destructiveCount int
 	windowStart      time.Time
 	mu               sync.Mutex
 }
 
 // NewRateLimiter creates a RateLimiter with the given limits.
-func NewRateLimiter(maxPerMin, maxPerReq, destructiveMax int) *RateLimiter {
+func NewRateLimiter(maxPerMin, maxPerReq, mutativeMax, destructiveMax int) *RateLimiter {
 	return &RateLimiter{
 		maxCallsPerMinute:  maxPerMin,
 		maxCallsPerRequest: maxPerReq,
+		mutativeLimit:      mutativeMax,
 		destructiveLimit:   destructiveMax,
 		windowStart:        time.Now(),
 	}
@@ -38,7 +43,7 @@ func NewRateLimiter(maxPerMin, maxPerReq, destructiveMax int) *RateLimiter {
 
 // Allow checks whether a tool call is permitted. It returns an error describing
 // which limit was exceeded, or nil if the call is allowed.
-func (r *RateLimiter) Allow(toolName string, isDestructive bool) error {
+func (r *RateLimiter) Allow(toolName string, isMutative, isDestructive bool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -57,12 +62,19 @@ func (r *RateLimiter) Allow(toolName string, isDestructive bool) error {
 		return fmt.Errorf("rate limit exceeded: max %d tool calls per request. Refusing to execute %s", r.maxCallsPerRequest, toolName)
 	}
 
+	if isMutative && r.mutativeCount >= r.mutativeLimit {
+		return fmt.Errorf("safety limit reached: max %d content changes per conversation. Start a new conversation to continue. Refusing to execute %s", r.mutativeLimit, toolName)
+	}
+
 	if isDestructive && r.destructiveCount >= r.destructiveLimit {
-		return fmt.Errorf("rate limit exceeded: max %d destructive actions per request. Refusing to execute %s", r.destructiveLimit, toolName)
+		return fmt.Errorf("safety limit reached: max %d destructive actions per conversation. Start a new conversation to continue. Refusing to execute %s", r.destructiveLimit, toolName)
 	}
 
 	r.minuteCount++
 	r.requestCount++
+	if isMutative {
+		r.mutativeCount++
+	}
 	if isDestructive {
 		r.destructiveCount++
 	}
@@ -74,5 +86,6 @@ func (r *RateLimiter) Reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.requestCount = 0
+	r.mutativeCount = 0
 	r.destructiveCount = 0
 }

--- a/internal/agent/ratelimit_test.go
+++ b/internal/agent/ratelimit_test.go
@@ -12,20 +12,20 @@ import (
 )
 
 func TestRateLimiterAllowsUnderLimit(t *testing.T) {
-	rl := NewRateLimiter(5, 3, 2)
-	if err := rl.Allow("search_series", false); err != nil {
+	rl := NewRateLimiter(5, 3, 2, 1)
+	if err := rl.Allow("search_series", false, false); err != nil {
 		t.Fatalf("expected allow, got %v", err)
 	}
-	if err := rl.Allow("add_series", true); err != nil {
+	if err := rl.Allow("add_series", true, false); err != nil {
 		t.Fatalf("expected allow, got %v", err)
 	}
 }
 
 func TestRateLimiterBlocksPerRequest(t *testing.T) {
-	rl := NewRateLimiter(100, 2, 100)
-	rl.Allow("search_series", false)
-	rl.Allow("get_queue", false)
-	err := rl.Allow("check_health", false)
+	rl := NewRateLimiter(100, 2, 100, 100)
+	rl.Allow("search_series", false, false)
+	rl.Allow("get_queue", false, false)
+	err := rl.Allow("check_health", false, false)
 	if err == nil {
 		t.Fatal("expected rate limit error")
 	}
@@ -35,10 +35,10 @@ func TestRateLimiterBlocksPerRequest(t *testing.T) {
 }
 
 func TestRateLimiterBlocksPerMinute(t *testing.T) {
-	rl := NewRateLimiter(2, 100, 100)
-	rl.Allow("search_series", false)
-	rl.Allow("get_queue", false)
-	err := rl.Allow("check_health", false)
+	rl := NewRateLimiter(2, 100, 100, 100)
+	rl.Allow("search_series", false, false)
+	rl.Allow("get_queue", false, false)
+	err := rl.Allow("check_health", false, false)
 	if err == nil {
 		t.Fatal("expected rate limit error")
 	}
@@ -48,9 +48,9 @@ func TestRateLimiterBlocksPerMinute(t *testing.T) {
 }
 
 func TestRateLimiterBlocksDestructive(t *testing.T) {
-	rl := NewRateLimiter(100, 100, 1)
-	rl.Allow("add_series", true)
-	err := rl.Allow("remove_failed", true)
+	rl := NewRateLimiter(100, 100, 100, 1)
+	rl.Allow("remove_failed", true, true)
+	err := rl.Allow("remove_failed", true, true)
 	if err == nil {
 		t.Fatal("expected rate limit error for destructive action")
 	}
@@ -59,24 +59,98 @@ func TestRateLimiterBlocksDestructive(t *testing.T) {
 	}
 }
 
+func TestRateLimiterBlocksMutative(t *testing.T) {
+	rl := NewRateLimiter(100, 100, 3, 100)
+	for i := 0; i < 3; i++ {
+		if err := rl.Allow("add_movie", true, false); err != nil {
+			t.Fatalf("expected allow on call %d, got %v", i+1, err)
+		}
+	}
+	err := rl.Allow("add_movie", true, false)
+	if err == nil {
+		t.Fatal("expected rate limit error for mutative action")
+	}
+	if !strings.Contains(err.Error(), "content changes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMutativeToolsAllowedUpTo20(t *testing.T) {
+	rl := NewRateLimiter(100, 100, 20, 5)
+	for i := 0; i < 20; i++ {
+		if err := rl.Allow("add_movie", true, false); err != nil {
+			t.Fatalf("expected allow on call %d, got %v", i+1, err)
+		}
+	}
+	err := rl.Allow("add_movie", true, false)
+	if err == nil {
+		t.Fatal("expected rate limit error after 20 mutative calls")
+	}
+}
+
+func TestDestructiveCountsTowardBothLimits(t *testing.T) {
+	rl := NewRateLimiter(100, 100, 5, 100)
+	// Use up mutative limit with destructive calls (which are implicitly mutative)
+	for i := 0; i < 5; i++ {
+		if err := rl.Allow("remove_failed", true, true); err != nil {
+			t.Fatalf("expected allow on call %d, got %v", i+1, err)
+		}
+	}
+	// Now even a mutative-only call should be blocked by the mutative limit
+	err := rl.Allow("add_movie", true, false)
+	if err == nil {
+		t.Fatal("expected mutative limit error")
+	}
+	if !strings.Contains(err.Error(), "content changes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestRateLimiterReset(t *testing.T) {
-	rl := NewRateLimiter(100, 1, 1)
-	rl.Allow("search_series", false)
-	if err := rl.Allow("search_series", false); err == nil {
+	rl := NewRateLimiter(100, 1, 1, 1)
+	rl.Allow("search_series", false, false)
+	if err := rl.Allow("search_series", false, false); err == nil {
 		t.Fatal("expected rate limit before reset")
 	}
 	rl.Reset()
-	if err := rl.Allow("search_series", false); err != nil {
+	if err := rl.Allow("search_series", false, false); err != nil {
 		t.Fatalf("expected allow after reset, got %v", err)
 	}
 }
 
+func TestIsMutative(t *testing.T) {
+	if !IsMutative("add_series") {
+		t.Error("add_series should be mutative")
+	}
+	if !IsMutative("add_movie") {
+		t.Error("add_movie should be mutative")
+	}
+	if !IsMutative("remove_failed") {
+		t.Error("remove_failed should be mutative (destructive implies mutative)")
+	}
+	if IsMutative("search_series") {
+		t.Error("search_series should not be mutative")
+	}
+}
+
 func TestIsDestructive(t *testing.T) {
-	if !IsDestructive("add_series") {
-		t.Error("add_series should be destructive")
+	if IsDestructive("add_series") {
+		t.Error("add_series should NOT be destructive (it's mutative)")
+	}
+	if IsDestructive("add_movie") {
+		t.Error("add_movie should NOT be destructive (it's mutative)")
 	}
 	if !IsDestructive("remove_failed") {
 		t.Error("remove_failed should be destructive")
+	}
+	if !IsDestructive("delete_series") {
+		t.Error("delete_series should be destructive")
+	}
+	if !IsDestructive("delete_movie") {
+		t.Error("delete_movie should be destructive")
+	}
+	if !IsDestructive("remove_blocklist_item") {
+		t.Error("remove_blocklist_item should be destructive")
 	}
 	if IsDestructive("search_series") {
 		t.Error("search_series should not be destructive")
@@ -84,16 +158,10 @@ func TestIsDestructive(t *testing.T) {
 	if IsDestructive("get_queue") {
 		t.Error("get_queue should not be destructive")
 	}
-	if IsDestructive("check_health") {
-		t.Error("check_health should not be destructive")
-	}
-	if IsDestructive("get_history") {
-		t.Error("get_history should not be destructive")
-	}
 }
 
 func TestRateLimiterDenialReturnedAsToolError(t *testing.T) {
-	rl := NewRateLimiter(100, 100, 0) // zero destructive allowed
+	rl := NewRateLimiter(100, 100, 0, 0) // zero mutative/destructive allowed
 	mock := &mockSonarr{}
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -106,8 +174,8 @@ func TestRateLimiterDenialReturnedAsToolError(t *testing.T) {
 	if !isErr {
 		t.Fatal("expected error from rate-limited tool")
 	}
-	if !strings.Contains(result, "destructive") {
-		t.Errorf("expected destructive limit message, got %s", result)
+	if !strings.Contains(result, "content changes") {
+		t.Errorf("expected content changes limit message, got %s", result)
 	}
 }
 

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -17,46 +17,58 @@ func generateSchema[T any]() anthropic.ToolInputSchemaParam {
 	}
 }
 
-// toolDef pairs an Anthropic tool definition with a destructive flag for rate limiting.
+// toolDef pairs an Anthropic tool definition with rate-limiting flags.
 type toolDef struct {
 	Param       anthropic.ToolParam
-	Destructive bool
+	Mutative    bool // state-changing but safe/additive
+	Destructive bool // removes or deletes data (implicitly also mutative)
 }
 
-// destructiveTools is the set of tools that modify state.
-var destructiveTools = map[string]bool{
-	"add_series":                  true,
-	"remove_failed":               true,
-	"update_series_monitoring":    true,
-	"trigger_series_search":       true,
-	"delete_series":               true,
-	"remove_blocklist_item":       true,
-	"grab_release":                true,
-	"update_episode_monitoring":   true,
-	"monitor_season_episodes":     true,
-	"add_movie":                   true,
-	"remove_failed_movie":         true,
-	"update_movie_monitoring":     true,
-	"delete_movie":                true,
-	"trigger_movie_search":        true,
-	"grab_movie_release":          true,
-	"remove_movie_blocklist_item":    true,
+// mutativeTools is the set of tools that change state but are additive/safe.
+var mutativeTools = map[string]bool{
+	"add_series":                     true,
+	"add_movie":                      true,
+	"approve_request":                true,
+	"decline_request":                true,
+	"retry_request":                  true,
+	"notebook_write":                 true,
+	"notebook_delete":                true,
+	"update_series_monitoring":       true,
+	"update_episode_monitoring":      true,
+	"monitor_season_episodes":        true,
+	"trigger_series_search":          true,
+	"trigger_movie_search":           true,
+	"update_movie_monitoring":        true,
+	"grab_release":                   true,
+	"grab_movie_release":             true,
 	"update_series_profile":          true,
 	"update_movie_profile":           true,
 	"update_movie_language_profile":  true,
 	"update_series_language_profile": true,
-	"approve_request":             true,
-	"decline_request":             true,
-	"delete_request":              true,
-	"retry_request":               true,
-	"notebook_write":              true,
-	"notebook_delete":             true,
-	"enable_indexer":              true,
-	"update_indexer_priority":     true,
-	"delete_indexer":              true,
+	"enable_indexer":                 true,
+	"update_indexer_priority":        true,
 }
 
-// IsDestructive reports whether the named tool modifies state.
+// destructiveTools is the set of tools that remove or delete data.
+// Destructive tools are implicitly also mutative.
+var destructiveTools = map[string]bool{
+	"remove_failed":              true,
+	"remove_failed_movie":        true,
+	"delete_series":              true,
+	"delete_movie":               true,
+	"remove_blocklist_item":      true,
+	"remove_movie_blocklist_item": true,
+	"delete_request":             true,
+	"delete_indexer":             true,
+}
+
+// IsMutative reports whether the named tool changes state.
+// Destructive tools are implicitly mutative.
+func IsMutative(name string) bool {
+	return mutativeTools[name] || destructiveTools[name]
+}
+
+// IsDestructive reports whether the named tool removes or deletes data.
 func IsDestructive(name string) bool {
 	return destructiveTools[name]
 }

--- a/internal/agent/tools_notebook.go
+++ b/internal/agent/tools_notebook.go
@@ -29,7 +29,7 @@ func notebookToolDefs() []toolDef {
 				Description: anthropic.String("Create or update a note in the persistent notebook. Use pinned type for high-signal info that should always be visible; use reference for detailed info looked up on demand. If updating, provide the existing note's ID."),
 				InputSchema: generateSchema[notebookWriteInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -51,7 +51,7 @@ func notebookToolDefs() []toolDef {
 				Description: anthropic.String("Delete a note from the notebook by its ID."),
 				InputSchema: generateSchema[notebookDeleteInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 	}
 }

--- a/internal/agent/tools_overseerr.go
+++ b/internal/agent/tools_overseerr.go
@@ -48,7 +48,7 @@ func overseerrToolDefs() []toolDef {
 				Description: anthropic.String("Approve a pending media request in Overseerr. This sends the media to Sonarr/Radarr for downloading."),
 				InputSchema: generateSchema[approveRequestInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -56,7 +56,7 @@ func overseerrToolDefs() []toolDef {
 				Description: anthropic.String("Decline a pending media request in Overseerr."),
 				InputSchema: generateSchema[declineRequestInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -79,7 +79,7 @@ func overseerrToolDefs() []toolDef {
 				Description: anthropic.String("Retry a failed Overseerr media request."),
 				InputSchema: generateSchema[retryRequestInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{

--- a/internal/agent/tools_prowlarr.go
+++ b/internal/agent/tools_prowlarr.go
@@ -67,7 +67,7 @@ func prowlarrToolDefs() []toolDef {
 				Description: anthropic.String("Enable or disable a Prowlarr indexer."),
 				InputSchema: generateSchema[enableIndexerInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -75,7 +75,7 @@ func prowlarrToolDefs() []toolDef {
 				Description: anthropic.String("Change the priority of a Prowlarr indexer."),
 				InputSchema: generateSchema[updateIndexerPriorityInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{

--- a/internal/agent/tools_radarr.go
+++ b/internal/agent/tools_radarr.go
@@ -83,7 +83,7 @@ func radarrToolDefs() []toolDef {
 				Description: anthropic.String("Add a movie to Radarr for monitoring and automatic downloading. Requires the TMDB ID from a search result."),
 				InputSchema: generateSchema[addMovieInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -162,7 +162,7 @@ func radarrToolDefs() []toolDef {
 				Description: anthropic.String("Update the monitoring status of a movie in Radarr. Fetches the movie, sets the monitored flag, and saves it back."),
 				InputSchema: generateSchema[updateMovieMonitoringInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -178,7 +178,7 @@ func radarrToolDefs() []toolDef {
 				Description: anthropic.String("Trigger an automatic search for a movie in Radarr. Sends a MoviesSearch command."),
 				InputSchema: generateSchema[triggerMovieSearchInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -186,7 +186,7 @@ func radarrToolDefs() []toolDef {
 				Description: anthropic.String("Grab a specific release for a movie from manual search results."),
 				InputSchema: generateSchema[grabMovieReleaseInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -202,7 +202,7 @@ func radarrToolDefs() []toolDef {
 				Description: anthropic.String("Update the quality profile for a movie. Use get_movie_quality_profiles to find available profile IDs and get_movie_detail to see the current profile."),
 				InputSchema: generateSchema[updateMovieProfileInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -224,7 +224,7 @@ func radarrToolDefs() []toolDef {
 				Description: anthropic.String("Update the language profile assigned to a movie. Fetches the movie, sets the language profile, and saves it back."),
 				InputSchema: generateSchema[updateMovieLanguageProfileInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 	}
 }

--- a/internal/agent/tools_sonarr.go
+++ b/internal/agent/tools_sonarr.go
@@ -104,7 +104,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Add a TV series to Sonarr for monitoring and automatic downloading. Requires the TVDB ID from a search result."),
 				InputSchema: generateSchema[addSeriesInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -197,7 +197,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Enable or disable monitoring for a specific season of a series. Use get_series_detail first to find the series ID."),
 				InputSchema: generateSchema[updateSeriesMonitoringInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -205,7 +205,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Trigger a search for downloads for a series or a specific season. Sonarr will search indexers and automatically grab matching releases."),
 				InputSchema: generateSchema[triggerSeriesSearchInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -229,7 +229,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Download a specific release found via manual_search. Requires the GUID and indexer ID from the search results."),
 				InputSchema: generateSchema[grabReleaseInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -237,7 +237,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Enable or disable monitoring for a single episode. Use get_episodes first to find the episode ID."),
 				InputSchema: generateSchema[updateEpisodeMonitoringInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -245,7 +245,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Enable or disable monitoring for all episodes in a specific season. Use get_series_detail first to find the series ID."),
 				InputSchema: generateSchema[monitorSeasonEpisodesInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -253,7 +253,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Update the quality profile for a series. Use get_quality_profiles to find available profile IDs and get_series_detail to see the current profile."),
 				InputSchema: generateSchema[updateSeriesProfileInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 		{
 			Param: anthropic.ToolParam{
@@ -268,7 +268,7 @@ func sonarrToolDefs() []toolDef {
 				Description: anthropic.String("Update the language profile assigned to a series. Fetches the series, sets the language profile ID, and saves it back."),
 				InputSchema: generateSchema[updateSeriesLanguageProfileInput](),
 			},
-			Destructive: true,
+			Mutative: true,
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ type AgentConfig struct {
 type RateLimitConfig struct {
 	MaxCallsPerMinute  int `yaml:"max_calls_per_minute"`
 	MaxCallsPerRequest int `yaml:"max_calls_per_request"`
+	MaxMutative        int `yaml:"max_mutative"`
 	MaxDestructive     int `yaml:"max_destructive"`
 }
 


### PR DESCRIPTION
## Summary
- Split the single `destructive` rate limit into two tiers: **mutative** (limit 20, for additive state changes like adding movies) and **destructive** (limit 5, for data-removing operations like deletes)
- Destructive tools count toward both limits, so truly dangerous operations are still tightly constrained
- Users can now add 10+ movies in one conversation without hitting safety limits

## Changes
- `internal/agent/ratelimit.go`: Added `mutativeLimit`/`mutativeCount` alongside existing destructive tracking; `Allow()` now takes both `isMutative` and `isDestructive` flags
- `internal/agent/tools.go`: Split `destructiveTools` map into `mutativeTools` (additive ops) and `destructiveTools` (removals/deletes); added `IsMutative()` function
- `internal/agent/tools_*.go`: Updated `toolDef` structs to use `Mutative: true` or `Destructive: true` as appropriate
- `internal/config/config.go`: Added `MaxMutative` field to `RateLimitConfig`
- `cmd/reel-life/main.go`: Wire up `MaxMutative` config to rate limiter constructor
- `internal/agent/ratelimit_test.go`: Updated existing tests, added tests for mutative limits, destructive limits, and cross-counting

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [x] `go vet ./...` clean
- [ ] Verify adding 10 movies in one conversation works without hitting limits
- [ ] Verify `remove_failed` is still limited to 5 per conversation

Run: 20260406-1249-ead9