### PR TITLE
fix(agent): forbid fabricating tool-call success in system prompt

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -47,7 +47,13 @@ Guidelines:
 - You have a persistent notebook for memory across conversations. Save useful observations: user preferences, recurring issues, operational patterns
 - Pinned notes are always visible to you; reference notes need to be looked up with notebook_read
 - Keep pinned notes concise and high-signal; use reference type for detailed information
-- Before creating a new note, check existing notes to avoid duplicates — update instead if a similar note exists`
+- Before creating a new note, check existing notes to avoid duplicates — update instead if a similar note exists
+
+Tool discipline — NEVER fabricate tool results:
+- Do NOT report past-tense success ("added", "queued", "imported", "requested", "updated", "approved") for any library operation unless a tool call for that operation succeeded in the current turn.
+- If you intend to add or request multiple items, call the tool for each one and only report what the tool results actually say succeeded.
+- If a tool fails or you didn't call it, say so plainly. "I tried to add X but the tool returned an error" or "I didn't call add_movie for Y" is far better than implying it happened.
+- The right pattern is: "I'll add these now" → call tools → "X added successfully (per add_movie result), Y failed because <error>, Z still pending".`
 
 const maxToolRounds = 10
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -925,6 +925,22 @@ func TestBuildSystemPromptNoWeather(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPromptToolDiscipline(t *testing.T) {
+	a := newTestAgent()
+	prompt := a.buildSystemPrompt(context.Background())
+	wantSubstrings := []string{
+		"Tool discipline",
+		"NEVER fabricate tool results",
+		"Do NOT report past-tense success",
+		"call the tool for each one",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("expected prompt to contain %q, but it did not", want)
+		}
+	}
+}
+
 func TestBuildSystemPromptWithWeather(t *testing.T) {
 	// Create a mock weather server.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Adds an explicit "Tool discipline" section to the agent system prompt instructing the model never to report past-tense success ("added", "queued", "requested", etc.) for library operations unless a corresponding tool call succeeded in the current turn.
- Adds a unit test (`TestBuildSystemPromptToolDiscipline`) verifying the new constraint text appears in `buildSystemPrompt` output.

## Why
Issue #45: a user added 5–6 movies via Telegram. The bot replied claiming each was "Added recently, waiting for automatic search", but auditing 30 days of journalctl showed exactly one `add_movie` invocation (Rocky Horror) — the other five titles were never sent to Radarr. The model was satisfying "be helpful and concise" by summarizing intended actions as if they had happened. The previous prompt did not explicitly forbid past-tense success language without a corresponding tool result.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `TestBuildSystemPromptToolDiscipline` exercises the new constraint text
- [x] `klaus _pre-review` — no findings

Run: 20260508-1715-db2b
Closes #45