### PR TITLE
fix: decode Sonarr/Radarr Release.Quality as nested object

### DIFF
--- a/internal/radarr/client_test.go
+++ b/internal/radarr/client_test.go
@@ -338,14 +338,14 @@ func TestManualSearch(t *testing.T) {
 		t.Fatalf("ManualSearch() error: %v", err)
 	}
 	if len(releases) != 1 || releases[0].GUID != "abc123" {
-		t.Errorf("unexpected releases: %+v", releases)
+		t.Fatalf("unexpected releases: %+v", releases)
 	}
-	got := releases[0].Quality.Quality.Name
+	got := releases[0].Quality.Definition.Name
 	if got != "Bluray-1080p" {
-		t.Errorf("Quality.Quality.Name = %q, want %q", got, "Bluray-1080p")
+		t.Errorf("Quality.Definition.Name = %q, want %q", got, "Bluray-1080p")
 	}
-	if releases[0].Quality.Quality.Resolution != 1080 {
-		t.Errorf("Quality.Quality.Resolution = %d, want 1080", releases[0].Quality.Quality.Resolution)
+	if releases[0].Quality.Definition.Resolution != 1080 {
+		t.Errorf("Quality.Definition.Resolution = %d, want 1080", releases[0].Quality.Definition.Resolution)
 	}
 	if releases[0].Quality.Revision.Version != 1 {
 		t.Errorf("Quality.Revision.Version = %d, want 1", releases[0].Quality.Revision.Version)

--- a/internal/radarr/client_test.go
+++ b/internal/radarr/client_test.go
@@ -292,6 +292,34 @@ func TestGetBlocklist(t *testing.T) {
 }
 
 func TestManualSearch(t *testing.T) {
+	// Fixture matches the real Radarr /api/v3/release response shape:
+	// "quality" is a nested object, not a string.
+	const fixture = `[
+		{
+			"guid": "abc123",
+			"title": "Inception.2010.1080p.BluRay.x264",
+			"indexer": "NZBgeek",
+			"indexerId": 3,
+			"quality": {
+				"quality": {
+					"id": 7,
+					"name": "Bluray-1080p",
+					"source": "bluray",
+					"resolution": 1080,
+					"modifier": "none"
+				},
+				"revision": {
+					"version": 1,
+					"real": 0,
+					"isRepack": false
+				}
+			},
+			"size": 5000000000,
+			"age": 2,
+			"rejected": false
+		}
+	]`
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v3/release" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -299,9 +327,8 @@ func TestManualSearch(t *testing.T) {
 		if r.URL.Query().Get("movieId") != "42" {
 			t.Errorf("movieId = %s, want 42", r.URL.Query().Get("movieId"))
 		}
-		json.NewEncoder(w).Encode([]Release{
-			{GUID: "abc123", Title: "Inception.2010.1080p", Indexer: "NZBgeek", Size: 5000000000},
-		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fixture))
 	}))
 	defer srv.Close()
 
@@ -312,6 +339,16 @@ func TestManualSearch(t *testing.T) {
 	}
 	if len(releases) != 1 || releases[0].GUID != "abc123" {
 		t.Errorf("unexpected releases: %+v", releases)
+	}
+	got := releases[0].Quality.Quality.Name
+	if got != "Bluray-1080p" {
+		t.Errorf("Quality.Quality.Name = %q, want %q", got, "Bluray-1080p")
+	}
+	if releases[0].Quality.Quality.Resolution != 1080 {
+		t.Errorf("Quality.Quality.Resolution = %d, want 1080", releases[0].Quality.Quality.Resolution)
+	}
+	if releases[0].Quality.Revision.Version != 1 {
+		t.Errorf("Quality.Revision.Version = %d, want 1", releases[0].Quality.Revision.Version)
 	}
 }
 

--- a/internal/radarr/types.go
+++ b/internal/radarr/types.go
@@ -86,11 +86,30 @@ type Release struct {
 	Title      string   `json:"title"`
 	Indexer    string   `json:"indexer"`
 	IndexerID  int      `json:"indexerId"`
-	Quality    string   `json:"quality"`
+	Quality    Quality  `json:"quality"`
 	Size       int64    `json:"size"`
 	Age        int      `json:"age"`
 	Rejected   bool     `json:"rejected"`
 	Rejections []string `json:"rejections,omitempty"`
+}
+
+type Quality struct {
+	Quality  QualityDefinition `json:"quality"`
+	Revision Revision          `json:"revision"`
+}
+
+type QualityDefinition struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Source     string `json:"source"`
+	Resolution int    `json:"resolution"`
+	Modifier   string `json:"modifier"`
+}
+
+type Revision struct {
+	Version  int  `json:"version"`
+	Real     int  `json:"real"`
+	IsRepack bool `json:"isRepack"`
 }
 
 type BlocklistItem struct {

--- a/internal/radarr/types.go
+++ b/internal/radarr/types.go
@@ -94,8 +94,8 @@ type Release struct {
 }
 
 type Quality struct {
-	Quality  QualityDefinition `json:"quality"`
-	Revision Revision          `json:"revision"`
+	Definition QualityDefinition `json:"quality"`
+	Revision   Revision          `json:"revision"`
 }
 
 type QualityDefinition struct {

--- a/internal/sonarr/client_test.go
+++ b/internal/sonarr/client_test.go
@@ -277,14 +277,14 @@ func TestManualSearch(t *testing.T) {
 		t.Fatalf("ManualSearch() error: %v", err)
 	}
 	if len(releases) != 1 || releases[0].Indexer != "NZBgeek" {
-		t.Errorf("unexpected releases: %+v", releases)
+		t.Fatalf("unexpected releases: %+v", releases)
 	}
-	got := releases[0].Quality.Quality.Name
+	got := releases[0].Quality.Definition.Name
 	if got != "HDTV-720p" {
-		t.Errorf("Quality.Quality.Name = %q, want %q", got, "HDTV-720p")
+		t.Errorf("Quality.Definition.Name = %q, want %q", got, "HDTV-720p")
 	}
-	if releases[0].Quality.Quality.Resolution != 720 {
-		t.Errorf("Quality.Quality.Resolution = %d, want 720", releases[0].Quality.Quality.Resolution)
+	if releases[0].Quality.Definition.Resolution != 720 {
+		t.Errorf("Quality.Definition.Resolution = %d, want 720", releases[0].Quality.Definition.Resolution)
 	}
 	if releases[0].Quality.Revision.Version != 1 {
 		t.Errorf("Quality.Revision.Version = %d, want 1", releases[0].Quality.Revision.Version)

--- a/internal/sonarr/client_test.go
+++ b/internal/sonarr/client_test.go
@@ -231,6 +231,34 @@ func TestGetLogs(t *testing.T) {
 }
 
 func TestManualSearch(t *testing.T) {
+	// Fixture matches the real Sonarr /api/v3/release response shape:
+	// "quality" is a nested object, not a string.
+	const fixture = `[
+		{
+			"guid": "xyz789",
+			"indexerId": 5,
+			"title": "Breaking.Bad.S01E01.720p.HDTV.x264",
+			"indexer": "NZBgeek",
+			"quality": {
+				"quality": {
+					"id": 4,
+					"name": "HDTV-720p",
+					"source": "television",
+					"resolution": 720,
+					"modifier": "none"
+				},
+				"revision": {
+					"version": 1,
+					"real": 0,
+					"isRepack": false
+				}
+			},
+			"size": 1400000000,
+			"age": 1,
+			"rejected": false
+		}
+	]`
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v3/release" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -238,9 +266,8 @@ func TestManualSearch(t *testing.T) {
 		if r.URL.Query().Get("episodeId") != "42" {
 			t.Errorf("episodeId = %s, want 42", r.URL.Query().Get("episodeId"))
 		}
-		json.NewEncoder(w).Encode([]Release{
-			{Title: "Breaking.Bad.S01E01", Indexer: "NZBgeek", Size: 1400000000},
-		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fixture))
 	}))
 	defer srv.Close()
 
@@ -251,6 +278,16 @@ func TestManualSearch(t *testing.T) {
 	}
 	if len(releases) != 1 || releases[0].Indexer != "NZBgeek" {
 		t.Errorf("unexpected releases: %+v", releases)
+	}
+	got := releases[0].Quality.Quality.Name
+	if got != "HDTV-720p" {
+		t.Errorf("Quality.Quality.Name = %q, want %q", got, "HDTV-720p")
+	}
+	if releases[0].Quality.Quality.Resolution != 720 {
+		t.Errorf("Quality.Quality.Resolution = %d, want 720", releases[0].Quality.Quality.Resolution)
+	}
+	if releases[0].Quality.Revision.Version != 1 {
+		t.Errorf("Quality.Revision.Version = %d, want 1", releases[0].Quality.Revision.Version)
 	}
 }
 

--- a/internal/sonarr/types.go
+++ b/internal/sonarr/types.go
@@ -109,8 +109,8 @@ type Release struct {
 }
 
 type Quality struct {
-	Quality  QualityDefinition `json:"quality"`
-	Revision Revision          `json:"revision"`
+	Definition QualityDefinition `json:"quality"`
+	Revision   Revision          `json:"revision"`
 }
 
 type QualityDefinition struct {

--- a/internal/sonarr/types.go
+++ b/internal/sonarr/types.go
@@ -101,11 +101,30 @@ type Release struct {
 	IndexerID  int      `json:"indexerId"`
 	Title      string   `json:"title"`
 	Indexer    string   `json:"indexer"`
-	Quality    string   `json:"quality"`
+	Quality    Quality  `json:"quality"`
 	Size       int64    `json:"size"`
 	Age        int      `json:"age"`
 	Rejected   bool     `json:"rejected"`
 	Rejections []string `json:"rejections,omitempty"`
+}
+
+type Quality struct {
+	Quality  QualityDefinition `json:"quality"`
+	Revision Revision          `json:"revision"`
+}
+
+type QualityDefinition struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Source     string `json:"source"`
+	Resolution int    `json:"resolution"`
+	Modifier   string `json:"modifier"`
+}
+
+type Revision struct {
+	Version  int  `json:"version"`
+	Real     int  `json:"real"`
+	IsRepack bool `json:"isRepack"`
 }
 
 type QualityProfile struct {


### PR DESCRIPTION
## Summary
- Sonarr's and Radarr's `/api/v3/release` responses return `quality` as a nested object (`{quality: {id, name, …}, revision: {…}}`), but `Release.Quality` was typed as `string`. Every `manual_search` / `manual_movie_search` invocation failed with `cannot unmarshal object into Go struct field Release.quality of type string`.
- Introduce `Quality`, `QualityDefinition`, and `Revision` types in both `internal/radarr/types.go` and `internal/sonarr/types.go`, and switch `Release.Quality` to use the nested struct.
- Update each client's `TestManualSearch` to drive a raw-JSON fixture that mirrors the real API shape, so the nested decode is exercised end-to-end. Both tests fail against the prior `string` typing and pass with the new structs.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test ./internal/radarr -run TestManualSearch -v`
- [x] `go test ./internal/sonarr -run TestManualSearch -v`

Closes #44

Run: 20260508-1714-da7d
Fixes #44