### PR TITLE
feat: surface tool errors as structured ToolResult

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -53,7 +53,12 @@ Tool discipline — NEVER fabricate tool results:
 - Do NOT report past-tense success ("added", "queued", "imported", "requested", "updated", "approved") for any library operation unless a tool call for that operation succeeded in the current turn.
 - If you intend to add or request multiple items, call the tool for each one and only report what the tool results actually say succeeded.
 - If a tool fails or you didn't call it, say so plainly. "I tried to add X but the tool returned an error" or "I didn't call add_movie for Y" is far better than implying it happened.
-- The right pattern is: "I'll add these now" → call tools → "X added successfully (per add_movie result), Y failed because <error>, Z still pending".`
+- The right pattern is: "I'll add these now" → call tools → "X added successfully (per add_movie result), Y failed because <error>, Z still pending".
+
+Tool errors:
+- Tool results are JSON. When the result has "success": false, treat it as a real failure — do NOT pretend the call succeeded or fabricate output the tool would have produced.
+- Read "error_kind" and "error" to understand what failed. If "retryable" is true you may try the call once more; otherwise report the failure plainly to the user and stop attempting the same operation.
+- If a tool fails repeatedly across a conversation, surface that pattern to the user rather than silently moving on.`
 
 const maxToolRounds = 10
 
@@ -213,8 +218,8 @@ func (a *Agent) Process(ctx context.Context, userMessage string, history []Turn)
 			case anthropic.TextBlock:
 				textResponse += v.Text
 			case anthropic.ToolUseBlock:
-				result, isErr := a.executeToolWithAudit(ctx, v.Name, v.Input, round, reqID)
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(v.ID, result, isErr))
+				tr := a.executeToolWithAudit(ctx, v.Name, v.Input, round, reqID)
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(v.ID, tr.Marshal(), !tr.Success))
 			}
 		}
 
@@ -232,7 +237,7 @@ func (a *Agent) Process(ctx context.Context, userMessage string, history []Turn)
 }
 
 // executeToolWithAudit wraps tool dispatch with rate limiting and audit logging.
-func (a *Agent) executeToolWithAudit(ctx context.Context, name string, rawInput json.RawMessage, round int, reqID string) (string, bool) {
+func (a *Agent) executeToolWithAudit(ctx context.Context, name string, rawInput json.RawMessage, round int, reqID string) ToolResult {
 	// Audit log: invocation
 	a.logger.Info("tool invocation",
 		"tool", name,
@@ -250,24 +255,25 @@ func (a *Agent) executeToolWithAudit(ctx context.Context, name string, rawInput 
 				"round", round,
 				"request_id", reqID,
 			)
-			return jsonError(err.Error()), true
+			return errorResult("rate_limited", err.Error(), true)
 		}
 	}
 
 	start := time.Now()
-	result, isErr := a.dispatchTool(ctx, name, rawInput)
+	result := a.dispatchTool(ctx, name, rawInput)
 	duration := time.Since(start)
 
 	// Audit log: result
 	a.logger.Info("tool result",
 		"tool", name,
-		"success", !isErr,
+		"success", result.Success,
+		"error_kind", result.ErrorKind,
 		"duration_ms", duration.Milliseconds(),
 		"round", round,
 		"request_id", reqID,
 	)
 
-	return result, isErr
+	return result
 }
 
 // sanitizeInput returns a string summary of tool input suitable for logging.
@@ -290,42 +296,51 @@ func sanitizeInput(raw json.RawMessage) string {
 	return string(out)
 }
 
-// dispatchTool executes a tool call and returns the JSON result string and whether it's an error.
-func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.RawMessage) (string, bool) {
-	if result, isErr, handled := a.dispatchSonarr(ctx, name, rawInput); handled {
-		return result, isErr
+// dispatchTool executes a tool call and returns a structured ToolResult.
+// Errors are first-class: classification and retryability are encoded into
+// the result so the agent loop can surface them to the model.
+func (a *Agent) dispatchTool(ctx context.Context, name string, rawInput json.RawMessage) ToolResult {
+	if result, handled := a.dispatchSonarr(ctx, name, rawInput); handled {
+		return result
 	}
-	if result, isErr, handled := a.dispatchRadarr(ctx, name, rawInput); handled {
-		return result, isErr
+	if result, handled := a.dispatchRadarr(ctx, name, rawInput); handled {
+		return result
 	}
-	if result, isErr, handled := a.dispatchProwlarr(ctx, name, rawInput); handled {
-		return result, isErr
+	if result, handled := a.dispatchProwlarr(ctx, name, rawInput); handled {
+		return result
 	}
-	if result, isErr, handled := a.dispatchOverseerr(ctx, name, rawInput); handled {
-		return result, isErr
+	if result, handled := a.dispatchOverseerr(ctx, name, rawInput); handled {
+		return result
 	}
-	if result, isErr, handled := a.dispatchNotebook(ctx, name, rawInput); handled {
-		return result, isErr
+	if result, handled := a.dispatchNotebook(ctx, name, rawInput); handled {
+		return result
 	}
-	return jsonError("unknown tool: " + name), true
+	return errorResult("invalid_input", "unknown tool: "+name, false)
 }
 
 // findIndexer fetches the indexer list from Prowlarr and returns the indexer with the given ID.
-// On failure, it returns a non-empty JSON error string.
-func (a *Agent) findIndexer(ctx context.Context, id int) (*prowlarr.Indexer, string) {
+// On failure, it returns a non-nil ToolResult describing the error.
+func (a *Agent) findIndexer(ctx context.Context, id int) (*prowlarr.Indexer, *ToolResult) {
 	indexers, err := a.prowlarr.ListIndexers(ctx)
 	if err != nil {
-		return nil, jsonError(err.Error())
+		r := errorResultFromErr(err)
+		return nil, &r
 	}
 	for i := range indexers {
 		if indexers[i].ID == id {
-			return &indexers[i], ""
+			return &indexers[i], nil
 		}
 	}
-	return nil, jsonError(fmt.Sprintf("indexer %d not found", id))
+	r := errorResult("not_found", fmt.Sprintf("indexer %d not found", id), false)
+	return nil, &r
 }
 
-func jsonError(msg string) string {
-	data, _ := json.Marshal(map[string]string{"error": msg})
-	return string(data)
+// marshalResult JSON-encodes a tool's success payload, returning a wrapped
+// ToolResult with classified marshal errors on failure.
+func marshalResult(result any) ToolResult {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return errorResult("decode", "failed to marshal result: "+err.Error(), false)
+	}
+	return successResult(string(data))
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -248,17 +248,17 @@ func TestDispatchSearchSeries(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(searchSeriesInput{Term: "breaking bad"})
-	result, isErr := a.dispatchTool(context.Background(), "search_series", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "search_series", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var series []sonarr.Series
-	if err := json.Unmarshal([]byte(result), &series); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &series); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(series) != 1 || series[0].Title != "Breaking Bad" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -272,13 +272,13 @@ func TestDispatchCheckHealth(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "check_health", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "check_health", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var checks []sonarr.HealthCheck
-	if err := json.Unmarshal([]byte(result), &checks); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &checks); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(checks) != 1 {
@@ -290,26 +290,26 @@ func TestDispatchRemoveFailed(t *testing.T) {
 	a := newTestAgent()
 
 	input, _ := json.Marshal(removeFailedInput{ID: 42, Blocklist: true})
-	result, isErr := a.dispatchTool(context.Background(), "remove_failed", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "remove_failed", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "removed" {
-		t.Errorf("expected status=removed, got %s", result)
+		t.Errorf("expected status=removed, got %s", result.Content)
 	}
 }
 
 func TestDispatchUnknownTool(t *testing.T) {
 	a := &Agent{sonarr: &mockSonarr{}, radarr: &mockRadarr{}, prowlarr: &mockProwlarr{}, overseerr: &mockOverseerr{}}
 
-	result, isErr := a.dispatchTool(context.Background(), "nonexistent", json.RawMessage("{}"))
-	if !isErr {
+	result := a.dispatchTool(context.Background(), "nonexistent", json.RawMessage("{}"))
+	if result.Success {
 		t.Fatal("expected error for unknown tool")
 	}
-	if result == "" {
+	if result.Error == "" {
 		t.Fatal("expected error message")
 	}
 }
@@ -328,13 +328,13 @@ func TestDispatchGetQueue(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_queue", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_queue", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var queue sonarr.QueuePage
-	if err := json.Unmarshal([]byte(result), &queue); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &queue); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if queue.TotalRecords != 2 {
@@ -351,13 +351,13 @@ func TestDispatchAddSeries(t *testing.T) {
 		QualityProfileID: 1,
 		RootFolderPath:   "/tv",
 	})
-	result, isErr := a.dispatchTool(context.Background(), "add_series", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "add_series", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var series sonarr.Series
-	if err := json.Unmarshal([]byte(result), &series); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &series); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if series.Title != "Breaking Bad" {
@@ -378,13 +378,13 @@ func TestDispatchGetHistory(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(getHistoryInput{PageSize: 10})
-	result, isErr := a.dispatchTool(context.Background(), "get_history", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_history", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var history sonarr.HistoryPage
-	if err := json.Unmarshal([]byte(result), &history); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &history); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if history.TotalRecords != 1 {
@@ -402,17 +402,17 @@ func TestDispatchSearchMovies(t *testing.T) {
 	a.radarr = mock
 
 	input, _ := json.Marshal(searchMoviesInput{Term: "inception"})
-	result, isErr := a.dispatchTool(context.Background(), "search_movies", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "search_movies", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var movies []radarr.Movie
-	if err := json.Unmarshal([]byte(result), &movies); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &movies); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(movies) != 1 || movies[0].Title != "Inception" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -425,13 +425,13 @@ func TestDispatchAddMovie(t *testing.T) {
 		QualityProfileID: 1,
 		RootFolderPath:   "/movies",
 	})
-	result, isErr := a.dispatchTool(context.Background(), "add_movie", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "add_movie", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var movie radarr.Movie
-	if err := json.Unmarshal([]byte(result), &movie); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &movie); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if movie.Title != "Inception" {
@@ -452,13 +452,13 @@ func TestDispatchGetMovieQueue(t *testing.T) {
 	a.radarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_movie_queue", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_movie_queue", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var queue radarr.QueuePage
-	if err := json.Unmarshal([]byte(result), &queue); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &queue); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if queue.TotalRecords != 1 {
@@ -476,13 +476,13 @@ func TestDispatchCheckMovieHealth(t *testing.T) {
 	a.radarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "check_movie_health", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "check_movie_health", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var checks []radarr.HealthCheck
-	if err := json.Unmarshal([]byte(result), &checks); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &checks); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(checks) != 1 {
@@ -494,15 +494,15 @@ func TestDispatchRemoveFailedMovie(t *testing.T) {
 	a := newTestAgent()
 
 	input, _ := json.Marshal(removeFailedMovieInput{ID: 42, Blocklist: true})
-	result, isErr := a.dispatchTool(context.Background(), "remove_failed_movie", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "remove_failed_movie", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "removed" {
-		t.Errorf("expected status=removed, got %s", result)
+		t.Errorf("expected status=removed, got %s", result.Content)
 	}
 }
 
@@ -519,13 +519,13 @@ func TestDispatchGetMovieHistory(t *testing.T) {
 	a.radarr = mock
 
 	input, _ := json.Marshal(getMovieHistoryInput{PageSize: 10})
-	result, isErr := a.dispatchTool(context.Background(), "get_movie_history", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_movie_history", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var history radarr.HistoryPage
-	if err := json.Unmarshal([]byte(result), &history); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &history); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if history.TotalRecords != 1 {
@@ -543,17 +543,17 @@ func TestDispatchListIndexers(t *testing.T) {
 	a.prowlarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "list_indexers", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "list_indexers", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var indexers []prowlarr.Indexer
-	if err := json.Unmarshal([]byte(result), &indexers); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &indexers); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(indexers) != 1 || indexers[0].Name != "NZBgeek" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -561,15 +561,15 @@ func TestDispatchTestIndexer(t *testing.T) {
 	a := newTestAgent()
 
 	input, _ := json.Marshal(testIndexerInput{ID: 5})
-	result, isErr := a.dispatchTool(context.Background(), "test_indexer", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "test_indexer", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "ok" {
-		t.Errorf("expected status=ok, got %s", result)
+		t.Errorf("expected status=ok, got %s", result.Content)
 	}
 }
 
@@ -585,13 +585,13 @@ func TestDispatchGetIndexerStats(t *testing.T) {
 	a.prowlarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_indexer_stats", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_indexer_stats", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var stats prowlarr.IndexerStats
-	if err := json.Unmarshal([]byte(result), &stats); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &stats); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(stats.Indexers) != 1 {
@@ -609,13 +609,13 @@ func TestDispatchCheckIndexerHealth(t *testing.T) {
 	a.prowlarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "check_indexer_health", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "check_indexer_health", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var checks []prowlarr.HealthCheck
-	if err := json.Unmarshal([]byte(result), &checks); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &checks); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(checks) != 1 {
@@ -633,17 +633,17 @@ func TestDispatchSearchIndexers(t *testing.T) {
 	a.prowlarr = mock
 
 	input, _ := json.Marshal(searchIndexersInput{Query: "breaking bad"})
-	result, isErr := a.dispatchTool(context.Background(), "search_indexers", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "search_indexers", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var results []prowlarr.SearchResult
-	if err := json.Unmarshal([]byte(result), &results); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &results); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(results) != 1 || results[0].Title != "Breaking.Bad.S01E01" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -651,11 +651,11 @@ func TestDispatchOverseerrNotConfigured(t *testing.T) {
 	a := &Agent{sonarr: &mockSonarr{}, radarr: &mockRadarr{}, prowlarr: &mockProwlarr{}}
 
 	for _, tool := range []string{"list_requests", "approve_request", "decline_request", "get_request_count", "search_media"} {
-		result, isErr := a.dispatchTool(context.Background(), tool, json.RawMessage("{}"))
-		if !isErr {
+		result := a.dispatchTool(context.Background(), tool, json.RawMessage("{}"))
+		if result.Success {
 			t.Errorf("%s: expected error when overseerr not configured", tool)
 		}
-		if result == "" {
+		if result.Error == "" {
 			t.Errorf("%s: expected error message", tool)
 		}
 	}
@@ -673,13 +673,13 @@ func TestDispatchListRequests(t *testing.T) {
 	a.overseerr = mock
 
 	input, _ := json.Marshal(listRequestsInput{Filter: "all", Take: 10})
-	result, isErr := a.dispatchTool(context.Background(), "list_requests", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "list_requests", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var page overseerr.RequestPage
-	if err := json.Unmarshal([]byte(result), &page); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &page); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(page.Results) != 1 {
@@ -691,15 +691,15 @@ func TestDispatchApproveRequest(t *testing.T) {
 	a := newTestAgent()
 
 	input, _ := json.Marshal(approveRequestInput{ID: 1})
-	result, isErr := a.dispatchTool(context.Background(), "approve_request", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "approve_request", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "approved" {
-		t.Errorf("expected status=approved, got %s", result)
+		t.Errorf("expected status=approved, got %s", result.Content)
 	}
 }
 
@@ -707,15 +707,15 @@ func TestDispatchDeclineRequest(t *testing.T) {
 	a := newTestAgent()
 
 	input, _ := json.Marshal(declineRequestInput{ID: 1})
-	result, isErr := a.dispatchTool(context.Background(), "decline_request", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "decline_request", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "declined" {
-		t.Errorf("expected status=declined, got %s", result)
+		t.Errorf("expected status=declined, got %s", result.Content)
 	}
 }
 
@@ -729,13 +729,13 @@ func TestDispatchGetRequestCount(t *testing.T) {
 	a.overseerr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_request_count", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_request_count", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var count overseerr.RequestCount
-	if err := json.Unmarshal([]byte(result), &count); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &count); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if count.Total != 17 {
@@ -756,17 +756,17 @@ func TestDispatchSearchMedia(t *testing.T) {
 	a.overseerr = mock
 
 	input, _ := json.Marshal(searchMediaInput{Query: "inception"})
-	result, isErr := a.dispatchTool(context.Background(), "search_media", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "search_media", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var results overseerr.SearchResults
-	if err := json.Unmarshal([]byte(result), &results); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &results); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if results.TotalResults != 1 || results.Results[0].Title != "Inception" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -774,11 +774,11 @@ func TestDispatchNotebookNotConfigured(t *testing.T) {
 	a := &Agent{sonarr: &mockSonarr{}, radarr: &mockRadarr{}, prowlarr: &mockProwlarr{}, overseerr: &mockOverseerr{}}
 
 	for _, tool := range []string{"notebook_write", "notebook_read", "notebook_list", "notebook_delete"} {
-		result, isErr := a.dispatchTool(context.Background(), tool, json.RawMessage("{}"))
-		if !isErr {
+		result := a.dispatchTool(context.Background(), tool, json.RawMessage("{}"))
+		if result.Success {
 			t.Errorf("%s: expected error when notebook not configured", tool)
 		}
-		if result == "" {
+		if result.Error == "" {
 			t.Errorf("%s: expected error message", tool)
 		}
 	}
@@ -792,15 +792,15 @@ func TestDispatchNotebookWrite(t *testing.T) {
 		Title:   "Test Note",
 		Content: "Some content",
 	})
-	result, isErr := a.dispatchTool(context.Background(), "notebook_write", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "notebook_write", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "saved" {
-		t.Errorf("expected status=saved, got %s", result)
+		t.Errorf("expected status=saved, got %s", result.Content)
 	}
 }
 
@@ -822,16 +822,16 @@ func TestDispatchNotebookWriteDuplicateTitle(t *testing.T) {
 		Title:   "User Preferences",
 		Content: "likes horror",
 	})
-	result, isErr := a.dispatchTool(ctx, "notebook_write", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(ctx, "notebook_write", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	// Should return a warning with existing_id.
 	var resp map[string]string
-	json.Unmarshal([]byte(result), &resp)
+	json.Unmarshal([]byte(result.Content), &resp)
 	if resp["warning"] == "" || resp["existing_id"] == "" {
-		t.Errorf("expected duplicate warning, got: %s", result)
+		t.Errorf("expected duplicate warning, got: %s", result.Content)
 	}
 }
 
@@ -848,13 +848,13 @@ func TestDispatchNotebookRead(t *testing.T) {
 	})
 
 	input, _ := json.Marshal(notebookReadInput{ID: "read-me"})
-	result, isErr := a.dispatchTool(ctx, "notebook_read", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(ctx, "notebook_read", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var note notebook.Note
-	if err := json.Unmarshal([]byte(result), &note); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &note); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if note.Title != "Readable" || note.Content != "hello" {
@@ -871,27 +871,27 @@ func TestDispatchNotebookList(t *testing.T) {
 
 	// List all.
 	input, _ := json.Marshal(notebookListInput{})
-	result, isErr := a.dispatchTool(ctx, "notebook_list", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(ctx, "notebook_list", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var summaries []notebook.NoteSummary
-	json.Unmarshal([]byte(result), &summaries)
+	json.Unmarshal([]byte(result.Content), &summaries)
 	if len(summaries) != 2 {
 		t.Fatalf("expected 2 summaries, got %d", len(summaries))
 	}
 
 	// List filtered.
 	input, _ = json.Marshal(notebookListInput{Type: "pinned"})
-	result, isErr = a.dispatchTool(ctx, "notebook_list", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result = a.dispatchTool(ctx, "notebook_list", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
-	json.Unmarshal([]byte(result), &summaries)
+	json.Unmarshal([]byte(result.Content), &summaries)
 	if len(summaries) != 1 || summaries[0].Title != "Pinned" {
-		t.Errorf("unexpected filtered result: %s", result)
+		t.Errorf("unexpected filtered result: %s", result.Content)
 	}
 }
 
@@ -902,15 +902,15 @@ func TestDispatchNotebookDelete(t *testing.T) {
 	a.notebook.Write(ctx, notebook.Note{ID: "del-me", Type: notebook.Reference, Title: "Delete", Content: "x"})
 
 	input, _ := json.Marshal(notebookDeleteInput{ID: "del-me"})
-	result, isErr := a.dispatchTool(ctx, "notebook_delete", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(ctx, "notebook_delete", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var status map[string]string
-	json.Unmarshal([]byte(result), &status)
+	json.Unmarshal([]byte(result.Content), &status)
 	if status["status"] != "deleted" {
-		t.Errorf("expected status=deleted, got %s", result)
+		t.Errorf("expected status=deleted, got %s", result.Content)
 	}
 }
 
@@ -1012,8 +1012,8 @@ func TestDispatchNotebookWriteInvalidType(t *testing.T) {
 		Title:   "Bad",
 		Content: "x",
 	})
-	_, isErr := a.dispatchTool(context.Background(), "notebook_write", input)
-	if !isErr {
+	result := a.dispatchTool(context.Background(), "notebook_write", input)
+	if result.Success {
 		t.Fatal("expected error for invalid note type")
 	}
 }
@@ -1026,17 +1026,17 @@ func TestDispatchGetSeriesDetail(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(getSeriesDetailInput{SeriesID: 1})
-	result, isErr := a.dispatchTool(context.Background(), "get_series_detail", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_series_detail", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var series sonarr.Series
-	if err := json.Unmarshal([]byte(result), &series); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &series); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if series.Title != "Breaking Bad" || series.EpisodeCount != 62 {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -1050,17 +1050,17 @@ func TestDispatchGetEpisodes(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(getEpisodesInput{SeriesID: 1})
-	result, isErr := a.dispatchTool(context.Background(), "get_episodes", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_episodes", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var episodes []sonarr.Episode
-	if err := json.Unmarshal([]byte(result), &episodes); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &episodes); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(episodes) != 1 || episodes[0].Title != "Pilot" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -1074,17 +1074,17 @@ func TestDispatchGetLogs(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(getLogsInput{PageSize: 10, Level: "error"})
-	result, isErr := a.dispatchTool(context.Background(), "get_logs", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_logs", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var logs []sonarr.LogRecord
-	if err := json.Unmarshal([]byte(result), &logs); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &logs); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(logs) != 1 || logs[0].Level != "error" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -1098,17 +1098,17 @@ func TestDispatchManualSearch(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(manualSearchInput{EpisodeID: 1})
-	result, isErr := a.dispatchTool(context.Background(), "manual_search", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "manual_search", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var releases []sonarr.Release
-	if err := json.Unmarshal([]byte(result), &releases); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &releases); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(releases) != 1 || releases[0].Indexer != "NZBgeek" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -1122,17 +1122,17 @@ func TestDispatchGetQualityProfiles(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_quality_profiles", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_quality_profiles", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var profiles []sonarr.QualityProfile
-	if err := json.Unmarshal([]byte(result), &profiles); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &profiles); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(profiles) != 1 || profiles[0].Name != "HD-1080p" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -1149,13 +1149,13 @@ func TestDispatchGetBlocklist(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(getBlocklistInput{PageSize: 10})
-	result, isErr := a.dispatchTool(context.Background(), "get_blocklist", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_blocklist", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var page sonarr.BlocklistPage
-	if err := json.Unmarshal([]byte(result), &page); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &page); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if page.TotalRecords != 1 {
@@ -1173,17 +1173,17 @@ func TestDispatchGetRootFolders(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_root_folders", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_root_folders", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var folders []sonarr.RootFolder
-	if err := json.Unmarshal([]byte(result), &folders); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &folders); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(folders) != 1 || folders[0].Path != "/tv" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }
 
@@ -1197,16 +1197,16 @@ func TestDispatchGetDownloadClients(t *testing.T) {
 	a.sonarr = mock
 
 	input, _ := json.Marshal(struct{}{})
-	result, isErr := a.dispatchTool(context.Background(), "get_download_clients", input)
-	if isErr {
-		t.Fatalf("unexpected error: %s", result)
+	result := a.dispatchTool(context.Background(), "get_download_clients", input)
+	if !result.Success {
+		t.Fatalf("unexpected error: %s", result.Error)
 	}
 
 	var clients []sonarr.DownloadClient
-	if err := json.Unmarshal([]byte(result), &clients); err != nil {
+	if err := json.Unmarshal([]byte(result.Content), &clients); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	if len(clients) != 1 || clients[0].Name != "SABnzbd" {
-		t.Errorf("unexpected result: %s", result)
+		t.Errorf("unexpected result: %s", result.Content)
 	}
 }

--- a/internal/agent/dispatch_notebook.go
+++ b/internal/agent/dispatch_notebook.go
@@ -8,11 +8,11 @@ import (
 	"github.com/patflynn/reel-life/internal/notebook"
 )
 
-func (a *Agent) dispatchNotebook(ctx context.Context, name string, rawInput json.RawMessage) (string, bool, bool) {
+func (a *Agent) dispatchNotebook(ctx context.Context, name string, rawInput json.RawMessage) (ToolResult, bool) {
 	if a.notebook == nil {
 		switch name {
 		case "notebook_write", "notebook_read", "notebook_list", "notebook_delete":
-			return jsonError("Notebook integration is not configured"), true, true
+			return notConfiguredError("Notebook"), true
 		}
 	}
 
@@ -23,11 +23,11 @@ func (a *Agent) dispatchNotebook(ctx context.Context, name string, rawInput json
 	case "notebook_write":
 		var input notebookWriteInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		noteType := notebook.NoteType(input.Type)
 		if noteType != notebook.Pinned && noteType != notebook.Reference {
-			return jsonError("type must be 'pinned' or 'reference'"), true, true
+			return errorResult("invalid_input", "type must be 'pinned' or 'reference'", false), true
 		}
 		// Check for duplicate titles to avoid creating redundant notes.
 		if input.ID == "" {
@@ -40,7 +40,7 @@ func (a *Agent) dispatchNotebook(ctx context.Context, name string, rawInput json
 							"existing_id": n.ID,
 							"title":       n.Title,
 						})
-						return string(data), false, true
+						return successResult(string(data)), true
 					}
 				}
 			}
@@ -57,13 +57,13 @@ func (a *Agent) dispatchNotebook(ctx context.Context, name string, rawInput json
 	case "notebook_read":
 		var input notebookReadInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.notebook.Read(ctx, input.ID)
 	case "notebook_list":
 		var input notebookListInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		summaries, listErr := a.notebook.List(ctx)
 		if listErr != nil {
@@ -82,24 +82,19 @@ func (a *Agent) dispatchNotebook(ctx context.Context, name string, rawInput json
 	case "notebook_delete":
 		var input notebookDeleteInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.notebook.Delete(ctx, input.ID)
 		if err == nil {
 			result = map[string]string{"status": "deleted"}
 		}
 	default:
-		return "", false, false
+		return ToolResult{}, false
 	}
 
 	if err != nil {
 		a.logger.Warn("tool error", "tool", name, "error", err)
-		return jsonError(err.Error()), true, true
+		return errorResultFromErr(err), true
 	}
-
-	data, marshalErr := json.Marshal(result)
-	if marshalErr != nil {
-		return jsonError("failed to marshal result: " + marshalErr.Error()), true, true
-	}
-	return string(data), false, true
+	return marshalResult(result), true
 }

--- a/internal/agent/dispatch_overseerr.go
+++ b/internal/agent/dispatch_overseerr.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 )
 
-func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput json.RawMessage) (string, bool, bool) {
+func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput json.RawMessage) (ToolResult, bool) {
 	if a.overseerr == nil {
 		switch name {
 		case "list_requests", "approve_request", "decline_request", "get_request_detail",
 			"delete_request", "retry_request", "get_request_count", "search_media":
-			return jsonError("Overseerr integration is not configured"), true, true
+			return notConfiguredError("Overseerr"), true
 		}
 	}
 
@@ -21,7 +21,7 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 	case "list_requests":
 		var input listRequestsInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		take := input.Take
 		if take == 0 {
@@ -31,7 +31,7 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 	case "approve_request":
 		var input approveRequestInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.overseerr.ApproveRequest(ctx, input.ID)
 		if err == nil {
@@ -40,7 +40,7 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 	case "decline_request":
 		var input declineRequestInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.overseerr.DeclineRequest(ctx, input.ID)
 		if err == nil {
@@ -49,13 +49,13 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 	case "get_request_detail":
 		var input getRequestDetailInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.overseerr.GetRequest(ctx, input.ID)
 	case "delete_request":
 		var input deleteRequestInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.overseerr.DeleteRequest(ctx, input.ID)
 		if err == nil {
@@ -64,7 +64,7 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 	case "retry_request":
 		var input retryRequestInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.overseerr.RetryRequest(ctx, input.ID)
 	case "get_request_count":
@@ -72,7 +72,7 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 	case "search_media":
 		var input searchMediaInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		page := input.Page
 		if page == 0 {
@@ -80,17 +80,12 @@ func (a *Agent) dispatchOverseerr(ctx context.Context, name string, rawInput jso
 		}
 		result, err = a.overseerr.SearchMedia(ctx, input.Query, page)
 	default:
-		return "", false, false
+		return ToolResult{}, false
 	}
 
 	if err != nil {
 		a.logger.Warn("tool error", "tool", name, "error", err)
-		return jsonError(err.Error()), true, true
+		return errorResultFromErr(err), true
 	}
-
-	data, marshalErr := json.Marshal(result)
-	if marshalErr != nil {
-		return jsonError("failed to marshal result: " + marshalErr.Error()), true, true
-	}
-	return string(data), false, true
+	return marshalResult(result), true
 }

--- a/internal/agent/dispatch_prowlarr.go
+++ b/internal/agent/dispatch_prowlarr.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 )
 
-func (a *Agent) dispatchProwlarr(ctx context.Context, name string, rawInput json.RawMessage) (string, bool, bool) {
+func (a *Agent) dispatchProwlarr(ctx context.Context, name string, rawInput json.RawMessage) (ToolResult, bool) {
 	if a.prowlarr == nil {
 		switch name {
 		case "list_indexers", "test_indexer", "test_all_indexers", "get_indexer_stats", "check_indexer_health",
 			"search_indexers", "enable_indexer", "update_indexer_priority", "delete_indexer":
-			return jsonError("Prowlarr integration is not configured"), true, true
+			return notConfiguredError("Prowlarr"), true
 		}
 	}
 
@@ -23,7 +23,7 @@ func (a *Agent) dispatchProwlarr(ctx context.Context, name string, rawInput json
 	case "test_indexer":
 		var input testIndexerInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.prowlarr.TestIndexer(ctx, input.ID)
 		if err == nil {
@@ -38,52 +38,47 @@ func (a *Agent) dispatchProwlarr(ctx context.Context, name string, rawInput json
 	case "search_indexers":
 		var input searchIndexersInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.prowlarr.Search(ctx, input.Query)
 	case "enable_indexer":
 		var input enableIndexerInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
-		found, errStr := a.findIndexer(ctx, input.IndexerID)
-		if errStr != "" {
-			return errStr, true, true
+		found, errResult := a.findIndexer(ctx, input.IndexerID)
+		if errResult != nil {
+			return *errResult, true
 		}
 		found.Enable = input.Enabled
 		result, err = a.prowlarr.UpdateIndexer(ctx, found)
 	case "update_indexer_priority":
 		var input updateIndexerPriorityInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
-		found, errStr := a.findIndexer(ctx, input.IndexerID)
-		if errStr != "" {
-			return errStr, true, true
+		found, errResult := a.findIndexer(ctx, input.IndexerID)
+		if errResult != nil {
+			return *errResult, true
 		}
 		found.Priority = input.Priority
 		result, err = a.prowlarr.UpdateIndexer(ctx, found)
 	case "delete_indexer":
 		var input deleteIndexerInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.prowlarr.DeleteIndexer(ctx, input.IndexerID)
 		if err == nil {
 			result = map[string]string{"status": "deleted"}
 		}
 	default:
-		return "", false, false
+		return ToolResult{}, false
 	}
 
 	if err != nil {
 		a.logger.Warn("tool error", "tool", name, "error", err)
-		return jsonError(err.Error()), true, true
+		return errorResultFromErr(err), true
 	}
-
-	data, marshalErr := json.Marshal(result)
-	if marshalErr != nil {
-		return jsonError("failed to marshal result: " + marshalErr.Error()), true, true
-	}
-	return string(data), false, true
+	return marshalResult(result), true
 }

--- a/internal/agent/dispatch_radarr.go
+++ b/internal/agent/dispatch_radarr.go
@@ -7,7 +7,7 @@ import (
 	"github.com/patflynn/reel-life/internal/radarr"
 )
 
-func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.RawMessage) (string, bool, bool) {
+func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.RawMessage) (ToolResult, bool) {
 	if a.radarr == nil {
 		switch name {
 		case "search_movies", "add_movie", "get_movie_queue", "get_movie_history", "check_movie_health", "remove_failed_movie",
@@ -15,7 +15,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 			"get_movie_blocklist", "manual_movie_search", "update_movie_monitoring", "delete_movie",
 			"trigger_movie_search", "grab_movie_release", "remove_movie_blocklist_item", "update_movie_profile",
 			"get_movie_language_profiles", "get_movie_custom_formats", "update_movie_language_profile":
-			return jsonError("Radarr integration is not configured"), true, true
+			return notConfiguredError("Radarr"), true
 		}
 	}
 
@@ -26,13 +26,13 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "search_movies":
 		var input searchMoviesInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.radarr.Search(ctx, input.Term)
 	case "add_movie":
 		var input addMovieInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		minAvail := input.MinimumAvailability
 		if minAvail == "" {
@@ -51,7 +51,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "get_movie_history":
 		var input getMovieHistoryInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		pageSize := input.PageSize
 		if pageSize == 0 {
@@ -63,7 +63,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "remove_failed_movie":
 		var input removeFailedMovieInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.radarr.RemoveFailed(ctx, input.ID, input.Blocklist)
 		if err == nil {
@@ -72,7 +72,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "get_movie_detail":
 		var input getMovieDetailInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.radarr.GetMovie(ctx, input.MovieID)
 	case "get_movie_quality_profiles":
@@ -84,7 +84,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "get_movie_blocklist":
 		var input getMovieBlocklistInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		pageSize := input.PageSize
 		if pageSize == 0 {
@@ -94,13 +94,13 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "manual_movie_search":
 		var input manualMovieSearchInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.radarr.ManualSearch(ctx, input.MovieID)
 	case "update_movie_monitoring":
 		var input updateMovieMonitoringInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		movie, getErr := a.radarr.GetMovie(ctx, input.MovieID)
 		if getErr != nil {
@@ -112,7 +112,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "delete_movie":
 		var input deleteMovieInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.radarr.DeleteMovie(ctx, input.MovieID, input.DeleteFiles)
 		if err == nil {
@@ -121,7 +121,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "trigger_movie_search":
 		var input triggerMovieSearchInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.radarr.Command(ctx, radarr.CommandRequest{
 			Name:     radarr.CommandMoviesSearch,
@@ -133,7 +133,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "grab_movie_release":
 		var input grabMovieReleaseInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.radarr.GrabRelease(ctx, input.GUID, input.IndexerID)
 		if err == nil {
@@ -142,7 +142,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "remove_movie_blocklist_item":
 		var input removeMovieBlocklistItemInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.radarr.DeleteBlocklistItem(ctx, input.ID)
 		if err == nil {
@@ -151,7 +151,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "update_movie_profile":
 		var input updateMovieProfileInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		movie, getErr := a.radarr.GetMovie(ctx, input.MovieID)
 		if getErr != nil {
@@ -167,7 +167,7 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 	case "update_movie_language_profile":
 		var input updateMovieLanguageProfileInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		movie, getErr := a.radarr.GetMovie(ctx, input.MovieID)
 		if getErr != nil {
@@ -177,17 +177,12 @@ func (a *Agent) dispatchRadarr(ctx context.Context, name string, rawInput json.R
 		movie.LanguageProfileID = input.LanguageProfileID
 		result, err = a.radarr.UpdateMovie(ctx, movie)
 	default:
-		return "", false, false
+		return ToolResult{}, false
 	}
 
 	if err != nil {
 		a.logger.Warn("tool error", "tool", name, "error", err)
-		return jsonError(err.Error()), true, true
+		return errorResultFromErr(err), true
 	}
-
-	data, marshalErr := json.Marshal(result)
-	if marshalErr != nil {
-		return jsonError("failed to marshal result: " + marshalErr.Error()), true, true
-	}
-	return string(data), false, true
+	return marshalResult(result), true
 }

--- a/internal/agent/dispatch_sonarr.go
+++ b/internal/agent/dispatch_sonarr.go
@@ -8,7 +8,7 @@ import (
 	"github.com/patflynn/reel-life/internal/sonarr"
 )
 
-func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.RawMessage) (string, bool, bool) {
+func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.RawMessage) (ToolResult, bool) {
 	if a.sonarr == nil {
 		switch name {
 		case "search_series", "add_series", "get_queue", "get_history", "check_health", "remove_failed",
@@ -17,7 +17,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 			"trigger_series_search", "delete_series", "remove_blocklist_item", "grab_release",
 			"update_episode_monitoring", "monitor_season_episodes", "update_series_profile",
 			"get_language_profiles", "update_series_language_profile":
-			return jsonError("Sonarr integration is not configured"), true, true
+			return notConfiguredError("Sonarr"), true
 		}
 	}
 
@@ -28,14 +28,14 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "search_series":
 		var input searchSeriesInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.Search(ctx, input.Term)
 
 	case "add_series":
 		var input addSeriesInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.Add(ctx, sonarr.AddSeriesRequest{
 			Title:            input.Title,
@@ -52,7 +52,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "get_history":
 		var input getHistoryInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		pageSize := input.PageSize
 		if pageSize == 0 {
@@ -66,7 +66,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "remove_failed":
 		var input removeFailedInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.sonarr.RemoveFailed(ctx, input.ID, input.Blocklist)
 		if err == nil {
@@ -76,28 +76,28 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "get_series_detail":
 		var input getSeriesDetailInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.GetSeries(ctx, input.SeriesID)
 
 	case "get_episodes":
 		var input getEpisodesInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.GetEpisodes(ctx, input.SeriesID)
 
 	case "get_logs":
 		var input getLogsInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.GetLogs(ctx, input.PageSize, input.Level)
 
 	case "manual_search":
 		var input manualSearchInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.ManualSearch(ctx, input.EpisodeID)
 
@@ -107,7 +107,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "get_blocklist":
 		var input getBlocklistInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.GetBlocklist(ctx, input.PageSize)
 
@@ -120,7 +120,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "update_series_monitoring":
 		var input updateSeriesMonitoringInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
 		if getErr != nil {
@@ -136,14 +136,14 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 			}
 		}
 		if !found {
-			return jsonError(fmt.Sprintf("season %d not found in series %q", input.SeasonNumber, series.Title)), true, true
+			return errorResult("not_found", fmt.Sprintf("season %d not found in series %q", input.SeasonNumber, series.Title), false), true
 		}
 		result, err = a.sonarr.UpdateSeries(ctx, series)
 
 	case "trigger_series_search":
 		var input triggerSeriesSearchInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		cmd := sonarr.CommandRequest{
 			Name:     "SeriesSearch",
@@ -158,7 +158,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "delete_series":
 		var input deleteSeriesInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.sonarr.DeleteSeries(ctx, input.SeriesID, input.DeleteFiles)
 		if err == nil {
@@ -168,7 +168,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "remove_blocklist_item":
 		var input removeBlocklistItemInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.sonarr.DeleteBlocklistItem(ctx, input.ID)
 		if err == nil {
@@ -178,14 +178,14 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "grab_release":
 		var input grabReleaseInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		result, err = a.sonarr.GrabRelease(ctx, input.GUID, input.IndexerID)
 
 	case "update_episode_monitoring":
 		var input updateEpisodeMonitoringInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		err = a.sonarr.MonitorEpisodes(ctx, []int{input.EpisodeID}, input.Monitored)
 		if err == nil {
@@ -195,7 +195,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "monitor_season_episodes":
 		var input monitorSeasonEpisodesInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		episodes, getErr := a.sonarr.GetEpisodes(ctx, input.SeriesID, input.SeasonNumber)
 		if getErr != nil {
@@ -207,7 +207,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 			ids = append(ids, ep.ID)
 		}
 		if len(ids) == 0 {
-			return jsonError(fmt.Sprintf("no episodes found for season %d", input.SeasonNumber)), true, true
+			return errorResult("not_found", fmt.Sprintf("no episodes found for season %d", input.SeasonNumber), false), true
 		}
 		err = a.sonarr.MonitorEpisodes(ctx, ids, input.Monitored)
 		if err == nil {
@@ -217,7 +217,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "update_series_profile":
 		var input updateSeriesProfileInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
 		if getErr != nil {
@@ -233,7 +233,7 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 	case "update_series_language_profile":
 		var input updateSeriesLanguageProfileInput
 		if err := json.Unmarshal(rawInput, &input); err != nil {
-			return jsonError("invalid input: " + err.Error()), true, true
+			return inputDecodeError(err), true
 		}
 		series, getErr := a.sonarr.GetSeries(ctx, input.SeriesID)
 		if getErr != nil {
@@ -244,17 +244,12 @@ func (a *Agent) dispatchSonarr(ctx context.Context, name string, rawInput json.R
 		result, err = a.sonarr.UpdateSeries(ctx, series)
 
 	default:
-		return "", false, false
+		return ToolResult{}, false
 	}
 
 	if err != nil {
 		a.logger.Warn("tool error", "tool", name, "error", err)
-		return jsonError(err.Error()), true, true
+		return errorResultFromErr(err), true
 	}
-
-	data, marshalErr := json.Marshal(result)
-	if marshalErr != nil {
-		return jsonError("failed to marshal result: " + marshalErr.Error()), true, true
-	}
-	return string(data), false, true
+	return marshalResult(result), true
 }

--- a/internal/agent/ratelimit_test.go
+++ b/internal/agent/ratelimit_test.go
@@ -170,12 +170,15 @@ func TestRateLimiterDenialReturnedAsToolError(t *testing.T) {
 	input, _ := json.Marshal(addSeriesInput{
 		Title: "Test", TVDBID: 1, QualityProfileID: 1, RootFolderPath: "/tv",
 	})
-	result, isErr := a.executeToolWithAudit(context.Background(), "add_series", input, 0, "req-1")
-	if !isErr {
+	result := a.executeToolWithAudit(context.Background(), "add_series", input, 0, "req-1")
+	if result.Success {
 		t.Fatal("expected error from rate-limited tool")
 	}
-	if !strings.Contains(result, "content changes") {
-		t.Errorf("expected content changes limit message, got %s", result)
+	if !strings.Contains(result.Error, "content changes") {
+		t.Errorf("expected content changes limit message, got %s", result.Error)
+	}
+	if result.ErrorKind != "rate_limited" {
+		t.Errorf("expected error_kind=rate_limited, got %q", result.ErrorKind)
 	}
 }
 

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -120,8 +120,11 @@ func classifyError(err error) (kind string, retryable bool) {
 		return "decode", false
 	}
 
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		return "network", true
+	}
+	if errors.Is(err, context.Canceled) {
+		return "network", false
 	}
 	if strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "no such host") ||

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -1,9 +1,139 @@
 package agent
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/invopop/jsonschema"
 )
+
+// ToolResult is the structured outcome of a single tool dispatch.
+// Errors are first-class — surfaced to the agent (not just logged) so the
+// model can decide whether to retry, report the failure, or escalate.
+//
+// Success results carry the original JSON payload in Content.
+// Failure results populate ErrorKind, Error, and Retryable.
+type ToolResult struct {
+	Success   bool   `json:"success"`
+	Content   string `json:"content,omitempty"`
+	ErrorKind string `json:"error_kind,omitempty"`
+	Error     string `json:"error,omitempty"`
+	Retryable bool   `json:"retryable,omitempty"`
+}
+
+// Marshal returns the wire form sent to the model as a tool result.
+// Successful results pass Content through untouched. Failures are encoded
+// as a JSON object with success=false and the structured error fields,
+// so the model can read and react to error_kind / retryable.
+func (r ToolResult) Marshal() string {
+	if r.Success {
+		return r.Content
+	}
+	payload := map[string]any{
+		"success":    false,
+		"error_kind": r.ErrorKind,
+		"error":      r.Error,
+		"retryable":  r.Retryable,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return `{"success":false,"error_kind":"unknown","error":"failed to encode tool error"}`
+	}
+	return string(data)
+}
+
+// successResult wraps a JSON payload string as a successful tool outcome.
+func successResult(content string) ToolResult {
+	return ToolResult{Success: true, Content: content}
+}
+
+// errorResult builds a failure ToolResult with explicit kind and retryability.
+func errorResult(kind, msg string, retryable bool) ToolResult {
+	return ToolResult{Success: false, ErrorKind: kind, Error: msg, Retryable: retryable}
+}
+
+// errorResultFromErr classifies an arbitrary error and returns a failure ToolResult.
+func errorResultFromErr(err error) ToolResult {
+	kind, retryable := classifyError(err)
+	return ToolResult{
+		Success:   false,
+		ErrorKind: kind,
+		Error:     err.Error(),
+		Retryable: retryable,
+	}
+}
+
+// inputDecodeError builds a ToolResult for failures unmarshalling a tool's input.
+func inputDecodeError(err error) ToolResult {
+	return errorResult("decode", "invalid input: "+err.Error(), false)
+}
+
+// notConfiguredError builds a ToolResult for tools whose backing service is unconfigured.
+func notConfiguredError(service string) ToolResult {
+	return errorResult("invalid_input", service+" integration is not configured", false)
+}
+
+var apiErrorStatusRegex = regexp.MustCompile(`API error (\d{3})`)
+
+// classifyError maps an error from a downstream client into one of the
+// ErrorKind values, plus a hint about whether a retry might succeed.
+//
+// The taxonomy is intentionally small and pragmatic:
+//   - decode:        JSON marshal/unmarshal failures
+//   - network:       transport-level or 5xx server errors (retryable)
+//   - auth:          HTTP 401/403
+//   - not_found:     HTTP 404
+//   - invalid_input: other 4xx (client must fix the call)
+//   - rate_limited:  HTTP 429 (retryable after a delay)
+//   - unknown:       anything we couldn't classify
+func classifyError(err error) (kind string, retryable bool) {
+	if err == nil {
+		return "", false
+	}
+	msg := err.Error()
+
+	if m := apiErrorStatusRegex.FindStringSubmatch(msg); len(m) == 2 {
+		status, _ := strconv.Atoi(m[1])
+		switch {
+		case status == 401 || status == 403:
+			return "auth", false
+		case status == 404:
+			return "not_found", false
+		case status == 429:
+			return "rate_limited", true
+		case status >= 400 && status < 500:
+			return "invalid_input", false
+		case status >= 500 && status < 600:
+			return "network", true
+		}
+	}
+
+	if strings.Contains(msg, "decode response") ||
+		strings.Contains(msg, "marshal ") ||
+		strings.Contains(msg, "unmarshal ") ||
+		strings.Contains(msg, "invalid character") {
+		return "decode", false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return "network", true
+	}
+	if strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "dial tcp") ||
+		strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "connection reset") {
+		return "network", true
+	}
+
+	return "unknown", false
+}
 
 func generateSchema[T any]() anthropic.ToolInputSchemaParam {
 	reflector := jsonschema.Reflector{

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/patflynn/reel-life/internal/radarr"
+)
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantKind      string
+		wantRetryable bool
+	}{
+		{
+			name:     "nil",
+			err:      nil,
+			wantKind: "",
+		},
+		{
+			name:     "auth 401",
+			err:      errors.New("get queue: API error 401: unauthorized"),
+			wantKind: "auth",
+		},
+		{
+			name:     "auth 403",
+			err:      errors.New("delete movie: API error 403: forbidden"),
+			wantKind: "auth",
+		},
+		{
+			name:     "not_found 404",
+			err:      errors.New("get movie: API error 404: not found"),
+			wantKind: "not_found",
+		},
+		{
+			name:          "rate_limited 429",
+			err:           errors.New("search movies: API error 429: too many requests"),
+			wantKind:      "rate_limited",
+			wantRetryable: true,
+		},
+		{
+			name:     "invalid_input 400",
+			err:      errors.New("add movie: API error 400: bad payload"),
+			wantKind: "invalid_input",
+		},
+		{
+			name:          "network 503",
+			err:           errors.New("get queue: API error 503: service unavailable"),
+			wantKind:      "network",
+			wantRetryable: true,
+		},
+		{
+			name:     "decode response",
+			err:      errors.New("manual search: decode response: unexpected EOF"),
+			wantKind: "decode",
+		},
+		{
+			name:     "marshal payload",
+			err:      errors.New("update movie: marshal movie: json: unsupported type"),
+			wantKind: "decode",
+		},
+		{
+			name:          "deadline exceeded",
+			err:           context.DeadlineExceeded,
+			wantKind:      "network",
+			wantRetryable: true,
+		},
+		{
+			name:          "connection refused",
+			err:           errors.New("dial tcp 127.0.0.1:7878: connect: connection refused"),
+			wantKind:      "network",
+			wantRetryable: true,
+		},
+		{
+			name:     "unknown",
+			err:      errors.New("something weird happened"),
+			wantKind: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotKind, gotRetryable := classifyError(tt.err)
+			if gotKind != tt.wantKind {
+				t.Errorf("classifyError kind = %q, want %q", gotKind, tt.wantKind)
+			}
+			if gotRetryable != tt.wantRetryable {
+				t.Errorf("classifyError retryable = %v, want %v", gotRetryable, tt.wantRetryable)
+			}
+		})
+	}
+}
+
+func TestToolResultMarshalSuccess(t *testing.T) {
+	r := successResult(`{"foo":"bar"}`)
+	if r.Marshal() != `{"foo":"bar"}` {
+		t.Errorf("success Marshal = %q, want raw content passthrough", r.Marshal())
+	}
+}
+
+func TestToolResultMarshalError(t *testing.T) {
+	r := errorResult("network", "boom", true)
+	var got map[string]any
+	if err := json.Unmarshal([]byte(r.Marshal()), &got); err != nil {
+		t.Fatalf("Marshal error result not valid JSON: %v", err)
+	}
+	if got["success"] != false {
+		t.Errorf("expected success=false, got %v", got["success"])
+	}
+	if got["error_kind"] != "network" {
+		t.Errorf("expected error_kind=network, got %v", got["error_kind"])
+	}
+	if got["error"] != "boom" {
+		t.Errorf("expected error=boom, got %v", got["error"])
+	}
+	if got["retryable"] != true {
+		t.Errorf("expected retryable=true, got %v", got["retryable"])
+	}
+}
+
+// failingRadarr returns a configurable error from ManualSearch to exercise
+// the dispatcher's error-classification path.
+type failingRadarr struct {
+	mockRadarr
+	manualSearchErr error
+}
+
+func (f *failingRadarr) ManualSearch(_ context.Context, _ int) ([]radarr.Release, error) {
+	return nil, f.manualSearchErr
+}
+
+func TestDispatchManualMovieSearchSurfacesClassifiedError(t *testing.T) {
+	mock := &failingRadarr{
+		manualSearchErr: fmt.Errorf("manual search: API error 404: movie not found"),
+	}
+	a := &Agent{radarr: mock, sonarr: &mockSonarr{}, prowlarr: &mockProwlarr{}, overseerr: &mockOverseerr{}, logger: slog.Default()}
+
+	input, _ := json.Marshal(manualMovieSearchInput{MovieID: 999})
+	result := a.dispatchTool(context.Background(), "manual_movie_search", input)
+
+	if result.Success {
+		t.Fatal("expected dispatch to return Success=false on client error")
+	}
+	if result.ErrorKind != "not_found" {
+		t.Errorf("expected ErrorKind=not_found, got %q", result.ErrorKind)
+	}
+	if result.Error == "" {
+		t.Error("expected Error message to be populated")
+	}
+	if result.Retryable {
+		t.Error("expected Retryable=false for not_found")
+	}
+
+	// Verify the wire form (what the model sees) carries the structured fields.
+	var wire map[string]any
+	if err := json.Unmarshal([]byte(result.Marshal()), &wire); err != nil {
+		t.Fatalf("Marshal output not valid JSON: %v", err)
+	}
+	if wire["success"] != false {
+		t.Errorf("wire success = %v, want false", wire["success"])
+	}
+	if wire["error_kind"] != "not_found" {
+		t.Errorf("wire error_kind = %v, want not_found", wire["error_kind"])
+	}
+}
+
+func TestDispatchInvalidInputClassifiedAsDecode(t *testing.T) {
+	a := &Agent{radarr: &mockRadarr{}, sonarr: &mockSonarr{}, prowlarr: &mockProwlarr{}, overseerr: &mockOverseerr{}, logger: slog.Default()}
+
+	// Trailing brace makes this invalid JSON; the dispatcher should classify as decode.
+	result := a.dispatchTool(context.Background(), "manual_movie_search", json.RawMessage(`{not json}`))
+	if result.Success {
+		t.Fatal("expected dispatch to return Success=false on bad input")
+	}
+	if result.ErrorKind != "decode" {
+		t.Errorf("expected ErrorKind=decode, got %q", result.ErrorKind)
+	}
+}

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -72,6 +72,12 @@ func TestClassifyError(t *testing.T) {
 			wantRetryable: true,
 		},
 		{
+			name:          "canceled",
+			err:           context.Canceled,
+			wantKind:      "network",
+			wantRetryable: false,
+		},
+		{
 			name:          "connection refused",
 			err:           errors.New("dial tcp 127.0.0.1:7878: connect: connection refused"),
 			wantKind:      "network",


### PR DESCRIPTION
## Summary
- Introduce a `ToolResult` type that all `dispatch_*.go` handlers return, with `success`, `error_kind`, `error`, and `retryable` fields. Failures are now serialized as JSON into the tool-result message so the model can read and reason about them rather than seeing a bare error string.
- Add `classifyError` to map downstream client errors into a small taxonomy (`decode`, `network`, `auth`, `not_found`, `invalid_input`, `rate_limited`, `unknown`) using HTTP status patterns from the existing clients plus transport-error matching for things like `connection refused` / `context.DeadlineExceeded`.
- Extend the agent's system prompt to teach the model that `success=false` is a real failure to surface to the user (not something to paper over) and to honor the `retryable` hint.

## Test plan
- [x] `go test ./...`
- [x] New `TestClassifyError` covers each `ErrorKind` branch (auth, not_found, rate_limited, invalid_input, network for both 5xx and transport, decode, unknown).
- [x] New dispatch test injects a 404 from a Radarr client and asserts the returned `ToolResult` has `Success=false`, `ErrorKind=not_found`, and a populated `Error` — and that the wire-form JSON the model sees carries the same fields.
- [x] Existing dispatch tests updated to use `result.Success` / `result.Content` against the new return type.
- [x] `klaus _pre-review` clean.

Run: 20260508-1715-4ab2
Fixes #46